### PR TITLE
Fix h2spec EOF Exception

### DIFF
--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2ServerFilter.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2ServerFilter.java
@@ -762,7 +762,7 @@ public class Http2ServerFilter extends Http2BaseFilter {
 
         // Check the PRI message payload
         final Buffer payload = httpContent.getContent();
-        if (payload.remaining() < PRI_PAYLOAD.length) {
+        if (payload.remaining() - 2 < PRI_PAYLOAD.length) {
             return false;
         }
 


### PR DESCRIPTION
PRI payload is sometimes parsed in two parts, an initial one which passes the conformance test, and then a second one which doesn't. The second one can cause an EOFException. By waiting for two more characters, parsing the PRI payload in one go is ensured.