### PR TITLE
PAYARA-3031 Fix HTTP/2 Trailer Issue

### DIFF
--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/DefaultOutputSink.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/DefaultOutputSink.java
@@ -232,10 +232,6 @@ class DefaultOutputSink implements StreamOutputSink {
                 break;
             }
         }
-
-        if (outputQueue.peek() != null && outputQueue.peek().trailer != null) {
-            LOGGER.warning("Trailer frame is going to get ignored.");
-        }
     }
 
     /**
@@ -445,7 +441,6 @@ class DefaultOutputSink implements StreamOutputSink {
                     // !!!!! LOCK the deflater
                     sendTrailers(completionHandler, messageCloner, (HttpTrailer) httpContent);
                 }
-                close();
                 return;
             }
         
@@ -711,7 +706,6 @@ class DefaultOutputSink implements StreamOutputSink {
                               final MessageCloner<Buffer> messageCloner,
                               final HttpTrailer httpContent)
     throws IOException {
-        http2Session.getDeflaterLock().lock();
         final boolean logging = NetLogger.isActive();
         final Map<String,String> capture = ((logging) ? new HashMap<>() : null);
         List<Http2Frame> trailerFrames =
@@ -730,7 +724,6 @@ class DefaultOutputSink implements StreamOutputSink {
         flushToConnectionOutputSink(trailerFrames, null,
                 new FlushCompletionHandler(completionHandler),
                 messageCloner, true);
-        http2Session.getDeflaterLock().unlock();
         close();
     }
 

--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/DefaultOutputSink.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/DefaultOutputSink.java
@@ -146,10 +146,10 @@ class DefaultOutputSink implements StreamOutputSink {
         }
         // update the available window size
         availStreamWindowSize.addAndGet(delta);
-        
+
         // try to write until window limit allows
-        while (isWantToWrite() &&
-            !outputQueue.isEmpty()) {
+        while ((isWantToWrite() && !outputQueue.isEmpty())
+            || (outputQueue.peek() != null && outputQueue.peek().trailer != null)) {
             
             // pick up the first output record in the queue
             OutputQueueRecord outputQueueRecord = outputQueue.poll();
@@ -178,6 +178,7 @@ class DefaultOutputSink implements StreamOutputSink {
 
             if (currentTrailer != null) {
                 try {
+                    outputQueueRecord = null;
                     sendTrailers(completionHandler, messageCloner, currentTrailer);
                 } catch (IOException ex) {
                     LOGGER.log(WARNING, "Error sending trailers.", ex);
@@ -233,18 +234,7 @@ class DefaultOutputSink implements StreamOutputSink {
         }
 
         if (outputQueue.peek() != null && outputQueue.peek().trailer != null) {
-            // pick up the first output record in the queue
-            final OutputQueueRecord outputQueueRecord = outputQueue.poll();
-
-            final FlushCompletionHandler completionHandler = outputQueueRecord.chunkedCompletionHandler;
-            final HttpTrailer currentTrailer = outputQueueRecord.trailer;
-            final MessageCloner messageCloner = outputQueueRecord.cloner;
-            try {
-                sendTrailers(completionHandler, messageCloner, currentTrailer);
-            } catch (IOException ex) {
-                LOGGER.log(WARNING, "Error sending trailers.", ex);
-            }
-            return;
+            LOGGER.warning("Trailer frame is going to get ignored.");
         }
     }
 
@@ -372,7 +362,7 @@ class DefaultOutputSink implements StreamOutputSink {
                                 .createBufferSource(data),
                             flushCompletionHandler,
                             (HttpTrailer) httpContent,
-                            isZeroSizeData);
+                            false);
                 } else {
                     outputQueueRecord = new OutputQueueRecord(
                             Source.factory(stream)

--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/DefaultOutputSink.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/DefaultOutputSink.java
@@ -16,13 +16,16 @@
 
 package org.glassfish.grizzly.http2;
 
+import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.WARNING;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.logging.Level;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Logger;
 import org.glassfish.grizzly.Buffer;
 import org.glassfish.grizzly.CompletionHandler;
@@ -117,10 +120,8 @@ class DefaultOutputSink implements StreamOutputSink {
     private void assertReady() throws IOException {
         // if the last frame (fin flag == 1) has been queued already - throw an IOException
         if (isTerminated()) {
-            if (LOGGER.isLoggable(Level.FINE)) {
-                LOGGER.log(Level.FINE, "Terminated!!! id={0} description={1}",
-                        new Object[]{stream.getId(), terminationFlag.getDescription()});
-            }
+            LOGGER.log(FINE, "Terminated!!! id={0} description={1}",
+                    new Object[]{stream.getId(), terminationFlag.getDescription()});
             throw new IOException(terminationFlag.getDescription());
         } else if (isLastFrameQueued) {
             throw new IOException("Write beyond end of stream");
@@ -148,7 +149,7 @@ class DefaultOutputSink implements StreamOutputSink {
         
         // try to write until window limit allows
         while (isWantToWrite() &&
-                !outputQueue.isEmpty()) {
+            !outputQueue.isEmpty()) {
             
             // pick up the first output record in the queue
             OutputQueueRecord outputQueueRecord = outputQueue.poll();
@@ -171,13 +172,24 @@ class DefaultOutputSink implements StreamOutputSink {
             boolean isLast = outputQueueRecord.isLast;
             final boolean isZeroSizeData = outputQueueRecord.isZeroSizeData;
             final Source resource = outputQueueRecord.resource;
+
+            final HttpTrailer currentTrailer = outputQueueRecord.trailer;
+            final MessageCloner messageCloner = outputQueueRecord.cloner;
+
+            if (currentTrailer != null) {
+                try {
+                    sendTrailers(completionHandler, messageCloner, currentTrailer);
+                } catch (IOException ex) {
+                    LOGGER.log(WARNING, "Error sending trailers.", ex);
+                }
+                return;
+            }
             
             // check if output record's buffer is fitting into window size
             // if not - split it into 2 parts: part to send, part to keep in the queue
             final int bytesToSend = checkOutputWindow(resource.remaining());
             final Buffer dataChunkToSend = resource.read(bytesToSend);
             final boolean hasRemaining = resource.hasRemaining();
-            
             
             // if there is a chunk to store
             if (hasRemaining) {
@@ -219,6 +231,21 @@ class DefaultOutputSink implements StreamOutputSink {
                 break;
             }
         }
+
+        if (outputQueue.peek() != null && outputQueue.peek().trailer != null) {
+            // pick up the first output record in the queue
+            final OutputQueueRecord outputQueueRecord = outputQueue.poll();
+
+            final FlushCompletionHandler completionHandler = outputQueueRecord.chunkedCompletionHandler;
+            final HttpTrailer currentTrailer = outputQueueRecord.trailer;
+            final MessageCloner messageCloner = outputQueueRecord.cloner;
+            try {
+                sendTrailers(completionHandler, messageCloner, currentTrailer);
+            } catch (IOException ex) {
+                LOGGER.log(WARNING, "Error sending trailers.", ex);
+            }
+            return;
+        }
     }
 
     /**
@@ -251,8 +278,8 @@ class DefaultOutputSink implements StreamOutputSink {
         List<Http2Frame> headerFrames = null;
         OutputQueueRecord outputQueueRecord = null;
         
-        boolean isDeflaterLocked = false;
-        
+        final ReentrantLock deflatorLock = http2Session.getDeflaterLock();
+
         try { // try-finally block to release deflater lock if needed
             
             // If HTTP header hasn't been committed - commit it
@@ -263,8 +290,7 @@ class DefaultOutputSink implements StreamOutputSink {
                         !httpContent.getContent().hasRemaining());
                 
                 // !!!!! LOCK the deflater
-                isDeflaterLocked = true;
-                http2Session.getDeflaterLock().lock();
+                deflatorLock.lock();
                 final boolean logging = NetLogger.isActive();
                 final Map<String,String> capture = ((logging) ? new HashMap<>() : null);
                 headerFrames = http2Session.encodeHttpHeaderAsHeaderFrames(
@@ -319,15 +345,6 @@ class DefaultOutputSink implements StreamOutputSink {
             Buffer data = httpContent.getContent();
             final int dataSize = data.remaining();
 
-            if (isLast && dataSize == 0) {
-                if (isTrailer) {
-                    // !!!!! LOCK the deflater
-                    isDeflaterLocked = true;
-                    sendTrailers(completionHandler, messageCloner, (HttpTrailer) httpContent);
-                }
-                close();
-                return;
-            }
 
             unflushedWritesCounter.incrementAndGet();
             final FlushCompletionHandler flushCompletionHandler =
@@ -349,10 +366,19 @@ class DefaultOutputSink implements StreamOutputSink {
                     isDataCloned = true;
                 }
 
-                outputQueueRecord = new OutputQueueRecord(
-                        Source.factory(stream)
-                            .createBufferSource(data),
-                        flushCompletionHandler, isLast, isZeroSizeData);
+                if (isTrailer) {
+                    outputQueueRecord = new OutputQueueRecord(
+                            Source.factory(stream)
+                                .createBufferSource(data),
+                            flushCompletionHandler,
+                            (HttpTrailer) httpContent,
+                            isZeroSizeData);
+                } else {
+                    outputQueueRecord = new OutputQueueRecord(
+                            Source.factory(stream)
+                                .createBufferSource(data),
+                            flushCompletionHandler, isLast, isZeroSizeData);
+                }
 
                 outputQueue.offer(outputQueueRecord);
 
@@ -367,7 +393,6 @@ class DefaultOutputSink implements StreamOutputSink {
             }
 
             // our element is first in the output queue
-
             final int remaining = data.remaining();
 
             // check if output record's buffer is fitting into window size
@@ -428,7 +453,6 @@ class DefaultOutputSink implements StreamOutputSink {
             if (isLast) {
                 if (isTrailer) {
                     // !!!!! LOCK the deflater
-                    isDeflaterLocked = true;
                     sendTrailers(completionHandler, messageCloner, (HttpTrailer) httpContent);
                 }
                 close();
@@ -436,8 +460,8 @@ class DefaultOutputSink implements StreamOutputSink {
             }
         
         } finally {
-            if (isDeflaterLocked) {
-                http2Session.getDeflaterLock().unlock();
+            if (deflatorLock.isHeldByCurrentThread()) {
+                deflatorLock.unlock();
             }
         }
         
@@ -603,7 +627,7 @@ class DefaultOutputSink implements StreamOutputSink {
             throws Http2StreamException {
         
         do { // Make sure current outputQueueRecord is not forgotten
-            
+
             // set the outputQueueRecord as the current
             outputQueue.setCurrentElement(outputQueueRecord);
 
@@ -612,9 +636,19 @@ class DefaultOutputSink implements StreamOutputSink {
                     outputQueue.compareAndSetCurrentElement(outputQueueRecord, null)) {
                 
                 // if we can send the output record now - do that
-                
                 final FlushCompletionHandler chunkedCompletionHandler =
                         outputQueueRecord.chunkedCompletionHandler;
+
+                final HttpTrailer currentTrailer = outputQueueRecord.trailer;
+                final MessageCloner messageCloner = outputQueueRecord.cloner;
+                if (currentTrailer != null) {
+                    try {
+                        sendTrailers(chunkedCompletionHandler, messageCloner, currentTrailer);
+                    } catch (IOException ex) {
+                        LOGGER.log(WARNING, "Error sending trailers.", ex);
+                    }
+                    return;
+                }
 
                 boolean isLast = outputQueueRecord.isLast;
                 final boolean isZeroSizeData = outputQueueRecord.isZeroSizeData;
@@ -623,7 +657,6 @@ class DefaultOutputSink implements StreamOutputSink {
                 
                 final int fitWindowLen = checkOutputWindow(currentResource.remaining());
                 final Buffer dataChunkToSend = currentResource.read(fitWindowLen);
-                
                 
                 // if there is a chunk to store
                 if (currentResource.hasRemaining()) {
@@ -707,11 +740,16 @@ class DefaultOutputSink implements StreamOutputSink {
         flushToConnectionOutputSink(trailerFrames, null,
                 new FlushCompletionHandler(completionHandler),
                 messageCloner, true);
+        http2Session.getDeflaterLock().unlock();
+        close();
     }
 
     private static class OutputQueueRecord extends AsyncQueueRecord<WriteResult> {
         private Source resource;
         private FlushCompletionHandler chunkedCompletionHandler;
+
+        private HttpTrailer trailer;
+        private MessageCloner cloner;
         
         private boolean isLast;
         
@@ -726,6 +764,18 @@ class DefaultOutputSink implements StreamOutputSink {
             this.chunkedCompletionHandler = completionHandler;
             this.isLast = isLast;
             this.isZeroSizeData = isZeroSizeData;
+        }
+        
+        public OutputQueueRecord(final Source resource,
+                final FlushCompletionHandler completionHandler,
+                final HttpTrailer trailer, final boolean isZeroDataSize) {
+            super(null, null, null);
+            
+            this.resource = resource;
+            this.chunkedCompletionHandler = completionHandler;
+            this.isLast = true;
+            this.trailer = trailer;
+            this.isZeroSizeData = isZeroDataSize;
         }
 
         private void incChunksCounter() {

--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2FrameCodec.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2FrameCodec.java
@@ -139,7 +139,7 @@ public class Http2FrameCodec {
         
         final int len = http2Session.getFrameSize(buffer);
         
-        if (len > http2Session.getLocalMaxFramePayloadSize() + Http2Frame.FRAME_HEADER_SIZE) {
+        if (len > http2Session.getPeerMaxFramePayloadSize() + Http2Frame.FRAME_HEADER_SIZE) {
             
             http2Session.onOversizedFrame(buffer);
 


### PR DESCRIPTION
- Fixes h2spec issue where local window size is used instead of peer frame size.
- Add trailer frames to output queue instead of sending immediately. This forces Grizzly to wait until all the data is sent before sending the final trailers.

As far as I can tell the issue is fixed and all the h2spec tests still pass. Needs a full review though, as this is probably the most disruptive change I've made to date.