### PR TITLE
CUSTCOM-83 Infinite Loop Causing CPU Hogging 2.3.31

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -55,7 +55,7 @@
     <artifactId>grizzly-bom</artifactId>
     <packaging>pom</packaging>
     <name>grizzly-bom</name>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
 
     <description>Grizzly Bill of Materials (BOM)</description>
 

--- a/extras/bundles/grizzly-httpservice-bundle/pom.xml
+++ b/extras/bundles/grizzly-httpservice-bundle/pom.xml
@@ -44,13 +44,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
     <name>Grizzly OSGi HttpService Bundle</name>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <groupId>org.glassfish.grizzly.osgi</groupId>
     <artifactId>grizzly-httpservice-bundle</artifactId>
     <build>

--- a/extras/bundles/pom.xml
+++ b/extras/bundles/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-extra-bundles</artifactId>
     <packaging>pom</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-extra-bundles</name>
 
     <modules>

--- a/extras/connection-pool/pom.xml
+++ b/extras/connection-pool/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>connection-pool</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>connection-pool</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/extras/grizzly-httpservice/pom.xml
+++ b/extras/grizzly-httpservice/pom.xml
@@ -44,14 +44,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
     <name>Grizzly OSGi HttpService</name>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <groupId>org.glassfish.grizzly.osgi</groupId>
     <artifactId>grizzly-httpservice</artifactId>
     <dependencies>

--- a/extras/http-server-jaxws/pom.xml
+++ b/extras/http-server-jaxws/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-server-jaxws</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-http-server-jaxws</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/extras/http-server-multipart/pom.xml
+++ b/extras/http-server-multipart/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-server-multipart</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-http-server-multipart</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/extras/http-servlet-extras/pom.xml
+++ b/extras/http-servlet-extras/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-servlet-extras</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-http-servlet-extras</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/extras/pom.xml
+++ b/extras/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-extras</artifactId>
     <packaging>pom</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-extras</name>
     <profiles>
         <profile>

--- a/extras/tls-sni/pom.xml
+++ b/extras/tls-sni/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>tls-sni</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>tls-sni</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/bundles/comet/pom.xml
+++ b/modules/bundles/comet/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-comet-server</artifactId>
     <packaging>jar</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-comet-server</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/bundles/core/pom.xml
+++ b/modules/bundles/core/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-core</artifactId>
     <packaging>jar</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-core</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/bundles/http-all/pom.xml
+++ b/modules/bundles/http-all/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-all</artifactId>
     <packaging>jar</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-all</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/bundles/http-servlet/pom.xml
+++ b/modules/bundles/http-servlet/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-servlet-server</artifactId>
     <packaging>jar</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-http-servlet-server</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/bundles/http/pom.xml
+++ b/modules/bundles/http/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-server-core</artifactId>
     <packaging>jar</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-http-server-core</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/bundles/pom.xml
+++ b/modules/bundles/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-bundles</artifactId>
     <packaging>pom</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-bundles</name>
 
     <modules>

--- a/modules/bundles/websockets/pom.xml
+++ b/modules/bundles/websockets/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-websockets-server</artifactId>
     <packaging>jar</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-websockets-server</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/comet/pom.xml
+++ b/modules/comet/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-comet</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-comet</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/grizzly/pom.xml
+++ b/modules/grizzly/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-framework</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-framework</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/ssl/SSLBaseFilter.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/ssl/SSLBaseFilter.java
@@ -1,7 +1,8 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2012-2016 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012-2019 Oracle and/or its affiliates and others.
+ * All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -36,6 +37,9 @@
  * and therefore, elected the GPL Version 2 license, then the option applies
  * only if the new code is made subject to such option by the copyright
  * holder.
+ * 
+ * Contributors:
+ *   Payara Services - Propagate stop action on a closed SSL connection
  */
 
 package org.glassfish.grizzly.ssl;
@@ -466,7 +470,11 @@ public class SSLBaseFilter extends BaseFilter {
 
             if (output.hasRemaining() || isClosed) {
                 ctx.setMessage(output);
-                return ctx.getInvokeAction(makeInputRemainder(sslCtx, ctx, input));
+                if (!isClosed) {
+                    return ctx.getInvokeAction(makeInputRemainder(sslCtx, ctx, input));
+                } else {
+                    LOGGER.finer("Closed SSL connection detected, terminating chain.");
+                }
             }
         }
 

--- a/modules/http-ajp/pom.xml
+++ b/modules/http-ajp/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-ajp</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-http-ajp</name>
     <url>http://grizzly.java.net</url>
     <build>

--- a/modules/http-server/pom.xml
+++ b/modules/http-server/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-server</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-http-server</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/http-servlet/pom.xml
+++ b/modules/http-servlet/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-servlet</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-http-servlet</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/http/pom.xml
+++ b/modules/http/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-http</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/monitoring/grizzly/pom.xml
+++ b/modules/monitoring/grizzly/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-framework-monitoring</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-framework-monitoring</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/monitoring/http-server/pom.xml
+++ b/modules/monitoring/http-server/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-server-monitoring</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-http-server-monitoring</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/monitoring/http/pom.xml
+++ b/modules/monitoring/http/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-monitoring</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-http-monitoring</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/monitoring/pom.xml
+++ b/modules/monitoring/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-monitoring</artifactId>
     <packaging>pom</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-monitoring</name>
     <modules>
         <module>grizzly</module>

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-modules</artifactId>
     <packaging>pom</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-modules</name>
     <profiles>
         <profile>

--- a/modules/portunif/pom.xml
+++ b/modules/portunif/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-portunif</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-portunif</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/spdy/pom.xml
+++ b/modules/spdy/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-spdy</artifactId>
     <!--<packaging>bundle</packaging>-->
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-spdy</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/websockets/pom.xml
+++ b/modules/websockets/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-websockets</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-websockets</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-bom</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>bom/pom.xml</relativePath>
     </parent>
 
@@ -52,7 +52,7 @@
     <artifactId>grizzly-project</artifactId>
     <packaging>pom</packaging>
     <name>grizzly-project</name>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <url>http://grizzly.java.net</url>
     <issueManagement>
         <system>GitHub</system>

--- a/samples/comet/comet-counter/pom.xml
+++ b/samples/comet/comet-counter/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-comet-counter</artifactId>
     <packaging>war</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-comet-counter</name>
     <url>https://grizzly.java.net</url>
     <dependencies>

--- a/samples/comet/pom.xml
+++ b/samples/comet/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-comet-samples</artifactId>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-comet-samples</name>
 
     <packaging>pom</packaging>

--- a/samples/connection-pool-samples/pom.xml
+++ b/samples/connection-pool-samples/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>connection-pool-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>connection-pool-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/framework-samples/pom.xml
+++ b/samples/framework-samples/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
      <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-framework-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-framework-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/http-ajp-samples/pom.xml
+++ b/samples/http-ajp-samples/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
      <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-http-ajp-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-http-ajp-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/http-jaxws-samples/pom.xml
+++ b/samples/http-jaxws-samples/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-http-jaxws-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-http-jaxws-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/http-multipart-samples/pom.xml
+++ b/samples/http-multipart-samples/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-http-multipart-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-http-multipart-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/http-samples/pom.xml
+++ b/samples/http-samples/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-http-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-http-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/http-server-samples/pom.xml
+++ b/samples/http-server-samples/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-http-server-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-http-server-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-samples</artifactId>
     <packaging>pom</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-samples</name>
     <modules>
         <module>framework-samples</module>

--- a/samples/portunif/pom.xml
+++ b/samples/portunif/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
      <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-portunif-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-portunif-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/spdy-samples/pom.xml
+++ b/samples/spdy-samples/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-spdy-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-spdy-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/tls-sni-samples/pom.xml
+++ b/samples/tls-sni-samples/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-tls-sni-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-tls-sni-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/websockets/chat-ssl/pom.xml
+++ b/samples/websockets/chat-ssl/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-websockets-chat-ssl</artifactId>
     <packaging>war</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-websockets-chat-ssl</name>
     <url>http://maven.apache.org</url>
     <build>

--- a/samples/websockets/chat/pom.xml
+++ b/samples/websockets/chat/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31</version>
+        <version>2.3.31.payara-p4</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-websockets-chat</artifactId>
     <packaging>war</packaging>
-    <version>2.3.31</version>
+    <version>2.3.31.payara-p4</version>
     <name>grizzly-websockets-chat</name>
     <url>http://maven.apache.org</url>
     <build>


### PR DESCRIPTION
See the first commit for the actual changes. To summarise this issue:

In some scenarios, an SSL connection is terminated before data is fully sent. In this case, the SSLBaseFilter will currently keep passing the incomplete data down the chain. An infinite loop was caused by the data handling filters deciding there's not enough data, and restarting the chain. This change makes sure that the SSLBaseFilter doesn't try to repeatedly process incomplete data on a terminated SSL connection