### PR TITLE
CUSTCOM-22 Prevent HTTP/2 Push When Disabled

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -31,7 +31,7 @@
     <artifactId>grizzly-bom</artifactId>
     <packaging>pom</packaging>
     <name>grizzly-bom</name>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
 
     <description>Grizzly Bill of Materials (BOM)</description>
 

--- a/extras/bundles/grizzly-httpservice-bundle/pom.xml
+++ b/extras/bundles/grizzly-httpservice-bundle/pom.xml
@@ -20,13 +20,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
     <name>Grizzly OSGi HttpService Bundle</name>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <groupId>org.glassfish.grizzly.osgi</groupId>
     <artifactId>grizzly-httpservice-bundle</artifactId>
     <build>

--- a/extras/bundles/pom.xml
+++ b/extras/bundles/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-extra-bundles</artifactId>
     <packaging>pom</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>grizzly-extra-bundles</name>
 
     <modules>

--- a/extras/connection-pool/pom.xml
+++ b/extras/connection-pool/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>connection-pool</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>connection-pool</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/extras/grizzly-httpservice/pom.xml
+++ b/extras/grizzly-httpservice/pom.xml
@@ -20,14 +20,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
     <name>Grizzly OSGi HttpService</name>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <groupId>org.glassfish.grizzly.osgi</groupId>
     <artifactId>grizzly-httpservice</artifactId>
     <dependencies>

--- a/extras/http-server-jaxws/pom.xml
+++ b/extras/http-server-jaxws/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-server-jaxws</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>grizzly-http-server-jaxws</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/extras/http-server-multipart/pom.xml
+++ b/extras/http-server-multipart/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-server-multipart</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>grizzly-http-server-multipart</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/extras/http-servlet-extras/pom.xml
+++ b/extras/http-servlet-extras/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-servlet-extras</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>grizzly-http-servlet-extras</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/extras/pom.xml
+++ b/extras/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-extras</artifactId>
     <packaging>pom</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>grizzly-extras</name>
     <profiles>
         <profile>

--- a/extras/tls-sni/pom.xml
+++ b/extras/tls-sni/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>tls-sni</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>tls-sni</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/bundles/comet/pom.xml
+++ b/modules/bundles/comet/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-comet-server</artifactId>
     <packaging>jar</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>grizzly-comet-server</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/bundles/core/pom.xml
+++ b/modules/bundles/core/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-core</artifactId>
     <packaging>jar</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>grizzly-core</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/bundles/http-all/pom.xml
+++ b/modules/bundles/http-all/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-all</artifactId>
     <packaging>jar</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>grizzly-all</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/bundles/http-servlet/pom.xml
+++ b/modules/bundles/http-servlet/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-servlet-server</artifactId>
     <packaging>jar</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>grizzly-http-servlet-server</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/bundles/http/pom.xml
+++ b/modules/bundles/http/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-server-core</artifactId>
     <packaging>jar</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>grizzly-http-server-core</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/bundles/pom.xml
+++ b/modules/bundles/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-bundles</artifactId>
     <packaging>pom</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>grizzly-bundles</name>
 
     <modules>

--- a/modules/bundles/websockets/pom.xml
+++ b/modules/bundles/websockets/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-websockets-server</artifactId>
     <packaging>jar</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>grizzly-websockets-server</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/comet/pom.xml
+++ b/modules/comet/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-comet</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>grizzly-comet</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/grizzly/pom.xml
+++ b/modules/grizzly/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-framework</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>grizzly-framework</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/http-ajp/pom.xml
+++ b/modules/http-ajp/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-ajp</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>grizzly-http-ajp</name>
     <url>https://projects.eclipse.org/projects/ee4j.grizzly</url>
     <build>

--- a/modules/http-server/pom.xml
+++ b/modules/http-server/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-server</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>grizzly-http-server</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/http-servlet/pom.xml
+++ b/modules/http-servlet/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-servlet</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>grizzly-http-servlet</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/http/pom.xml
+++ b/modules/http/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>grizzly-http</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/http2/pom.xml
+++ b/modules/http2/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http2</artifactId>
     <!--<packaging>bundle</packaging>-->
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>grizzly-http2</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2Session.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2Session.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2012, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates and others.
+ * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -12,6 +13,9 @@
  * https://www.gnu.org/software/classpath/license.html.
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * 
+ * Contributors:
+ *  Payara Services - Prevent push when globally disabled
  */
 
 package org.glassfish.grizzly.http2;
@@ -505,7 +509,7 @@ public class Http2Session {
      *  returns <code>false</code>.  Push is enabled by default.
      */
     public boolean isPushEnabled() {
-        return pushEnabled;
+        return pushEnabled && http2Configuration.isPushEnabled();
     }
 
     /**

--- a/modules/monitoring/grizzly/pom.xml
+++ b/modules/monitoring/grizzly/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-framework-monitoring</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>grizzly-framework-monitoring</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/monitoring/http-server/pom.xml
+++ b/modules/monitoring/http-server/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-server-monitoring</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>grizzly-http-server-monitoring</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/monitoring/http/pom.xml
+++ b/modules/monitoring/http/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-monitoring</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>grizzly-http-monitoring</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/monitoring/pom.xml
+++ b/modules/monitoring/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-monitoring</artifactId>
     <packaging>pom</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>grizzly-monitoring</name>
     <modules>
         <module>grizzly</module>

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-modules</artifactId>
     <packaging>pom</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>grizzly-modules</name>
     <profiles>
         <profile>

--- a/modules/portunif/pom.xml
+++ b/modules/portunif/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-portunif</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>grizzly-portunif</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/websockets/pom.xml
+++ b/modules/websockets/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-websockets</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>grizzly-websockets</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-bom</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>bom/pom.xml</relativePath>
     </parent>
 
@@ -28,7 +28,7 @@
     <artifactId>grizzly-project</artifactId>
     <packaging>pom</packaging>
     <name>grizzly-project</name>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <url>http://grizzly.java.net</url>
     <issueManagement>
         <system>GitHub</system>

--- a/samples/connection-pool-samples/pom.xml
+++ b/samples/connection-pool-samples/pom.xml
@@ -15,14 +15,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>connection-pool-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>connection-pool-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/framework-samples/pom.xml
+++ b/samples/framework-samples/pom.xml
@@ -15,14 +15,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
      <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-framework-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>grizzly-framework-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/http-ajp-samples/pom.xml
+++ b/samples/http-ajp-samples/pom.xml
@@ -15,14 +15,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
      <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-http-ajp-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>grizzly-http-ajp-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/http-jaxws-samples/pom.xml
+++ b/samples/http-jaxws-samples/pom.xml
@@ -15,14 +15,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-http-jaxws-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>grizzly-http-jaxws-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/http-multipart-samples/pom.xml
+++ b/samples/http-multipart-samples/pom.xml
@@ -15,14 +15,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-http-multipart-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>grizzly-http-multipart-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/http-samples/pom.xml
+++ b/samples/http-samples/pom.xml
@@ -15,14 +15,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-http-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>grizzly-http-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/http-server-samples/pom.xml
+++ b/samples/http-server-samples/pom.xml
@@ -15,14 +15,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-http-server-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>grizzly-http-server-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -15,14 +15,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-samples</artifactId>
     <packaging>pom</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>grizzly-samples</name>
     <modules>
         <module>framework-samples</module>

--- a/samples/portunif/pom.xml
+++ b/samples/portunif/pom.xml
@@ -15,14 +15,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
      <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-portunif-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>grizzly-portunif-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/tls-sni-samples/pom.xml
+++ b/samples/tls-sni-samples/pom.xml
@@ -15,14 +15,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p1</version>
+        <version>2.4.4.payara-p2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-tls-sni-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p1</version>
+    <version>2.4.4.payara-p2</version>
     <name>grizzly-tls-sni-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>


### PR DESCRIPTION
ApplicationPushBuilder checks if the current stream supports push, which in turn checks if the session does. The session did not consult the global configuration.

So in essence:

ApplicationPushBuilder.push() -> Http2Stream.isPushEnabled() -> Http2Session.isPushEnabled() **-> Http2Configuration.isPushEnabled()**