### PR TITLE
FISH-464 Race conditions and stability

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -31,7 +31,7 @@
     <artifactId>grizzly-bom</artifactId>
     <packaging>pom</packaging>
     <name>grizzly-bom</name>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
 
     <description>Grizzly Bill of Materials (BOM)</description>
 

--- a/extras/bundles/grizzly-httpservice-bundle/pom.xml
+++ b/extras/bundles/grizzly-httpservice-bundle/pom.xml
@@ -20,13 +20,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
     <name>Grizzly OSGi HttpService Bundle</name>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <groupId>org.glassfish.grizzly.osgi</groupId>
     <artifactId>grizzly-httpservice-bundle</artifactId>
     <build>

--- a/extras/bundles/pom.xml
+++ b/extras/bundles/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-extra-bundles</artifactId>
     <packaging>pom</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>grizzly-extra-bundles</name>
 
     <modules>

--- a/extras/connection-pool/pom.xml
+++ b/extras/connection-pool/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>connection-pool</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>connection-pool</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/extras/grizzly-httpservice/pom.xml
+++ b/extras/grizzly-httpservice/pom.xml
@@ -20,14 +20,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
     <name>Grizzly OSGi HttpService</name>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <groupId>org.glassfish.grizzly.osgi</groupId>
     <artifactId>grizzly-httpservice</artifactId>
     <dependencies>

--- a/extras/http-server-jaxws/pom.xml
+++ b/extras/http-server-jaxws/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-server-jaxws</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>grizzly-http-server-jaxws</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/extras/http-server-multipart/pom.xml
+++ b/extras/http-server-multipart/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-server-multipart</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>grizzly-http-server-multipart</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/extras/http-servlet-extras/pom.xml
+++ b/extras/http-servlet-extras/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-servlet-extras</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>grizzly-http-servlet-extras</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/extras/pom.xml
+++ b/extras/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-extras</artifactId>
     <packaging>pom</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>grizzly-extras</name>
     <profiles>
         <profile>

--- a/extras/tls-sni/pom.xml
+++ b/extras/tls-sni/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>tls-sni</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>tls-sni</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/bundles/comet/pom.xml
+++ b/modules/bundles/comet/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-comet-server</artifactId>
     <packaging>jar</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>grizzly-comet-server</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/bundles/core/pom.xml
+++ b/modules/bundles/core/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-core</artifactId>
     <packaging>jar</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>grizzly-core</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/bundles/http-all/pom.xml
+++ b/modules/bundles/http-all/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-all</artifactId>
     <packaging>jar</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>grizzly-all</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/bundles/http-servlet/pom.xml
+++ b/modules/bundles/http-servlet/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-servlet-server</artifactId>
     <packaging>jar</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>grizzly-http-servlet-server</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/bundles/http/pom.xml
+++ b/modules/bundles/http/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-server-core</artifactId>
     <packaging>jar</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>grizzly-http-server-core</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/bundles/pom.xml
+++ b/modules/bundles/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-bundles</artifactId>
     <packaging>pom</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>grizzly-bundles</name>
 
     <modules>

--- a/modules/bundles/websockets/pom.xml
+++ b/modules/bundles/websockets/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-websockets-server</artifactId>
     <packaging>jar</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>grizzly-websockets-server</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/comet/pom.xml
+++ b/modules/comet/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-comet</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>grizzly-comet</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/grizzly/pom.xml
+++ b/modules/grizzly/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-framework</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>grizzly-framework</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/CloseReason.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/CloseReason.java
@@ -20,20 +20,20 @@ import java.io.IOException;
 
 /**
  * An object, describing the reason why {@link Connection} was closed.
- * 
+ *
  * @author Alexey Stashok
  */
 public class CloseReason {
     private static final IOException LOCALLY_CLOSED;
     private static final IOException REMOTELY_CLOSED;
-    
+
     public static final CloseReason LOCALLY_CLOSED_REASON;
     public static final CloseReason REMOTELY_CLOSED_REASON;
-    
+
     static {
         LOCALLY_CLOSED = new IOException("Locally closed");
         LOCALLY_CLOSED.setStackTrace(new StackTraceElement[0]);
-        
+
         REMOTELY_CLOSED = new IOException("Remotely closed");
         REMOTELY_CLOSED.setStackTrace(new StackTraceElement[0]);
 
@@ -42,7 +42,7 @@ public class CloseReason {
         REMOTELY_CLOSED_REASON =
                 new CloseReason(org.glassfish.grizzly.CloseType.REMOTELY, REMOTELY_CLOSED);
     }
-    
+
     private final CloseType type;
     private final IOException cause;
 
@@ -57,7 +57,7 @@ public class CloseReason {
 
     /**
      * Return information whether {@link Connection} was closed locally or remotely.
-     * 
+     *
      * @return information whether {@link Connection} was closed locally or remotely
      */
     public CloseType getType() {
@@ -67,13 +67,22 @@ public class CloseReason {
     /**
      * Returns information about an error, that caused the {@link Connection} to
      * be closed.
-     * 
+     *
      * If the cause wasn't specified by user - the default value {@link #DEFAULT_CAUSE} will be returned.
-     * 
+     *
      * @return information about an error, that caused the {@link Connection} to
      * be closed
      */
     public IOException getCause() {
         return cause;
+    }
+
+
+    /**
+     * Returns also type and cause.
+     */
+    @Override
+    public String toString() {
+        return super.toString() + "[type="+ getType() + ", cause=" + getCause() + "]";
     }
 }

--- a/modules/grizzly/src/main/java/org/glassfish/grizzly/asyncqueue/TaskQueue.java
+++ b/modules/grizzly/src/main/java/org/glassfish/grizzly/asyncqueue/TaskQueue.java
@@ -27,38 +27,38 @@ import org.glassfish.grizzly.WriteHandler;
  * Class represents common implementation of asynchronous processing queue.
  *
  * @param <E> {@link AsyncQueueRecord} type
- * 
+ *
  * @author Alexey Stashok
  */
 public final class TaskQueue<E extends AsyncQueueRecord> {
     private volatile boolean isClosed;
-    
+
     /**
      * The queue of tasks, which will be processed asynchronously
      */
     private final Queue<E> queue;
-    
+
     private static final AtomicReferenceFieldUpdater<TaskQueue, AsyncQueueRecord> currentElementUpdater =
             AtomicReferenceFieldUpdater.newUpdater(TaskQueue.class, AsyncQueueRecord.class, "currentElement");
     private volatile E currentElement;
-    
+
     private static final AtomicIntegerFieldUpdater<TaskQueue> spaceInBytesUpdater =
             AtomicIntegerFieldUpdater.newUpdater(TaskQueue.class, "spaceInBytes");
     private volatile int spaceInBytes;
-    
+
     private final MutableMaxQueueSize maxQueueSizeHolder;
-    
+
     private static final AtomicIntegerFieldUpdater<TaskQueue> writeHandlersCounterUpdater =
             AtomicIntegerFieldUpdater.newUpdater(TaskQueue.class, "writeHandlersCounter");
     private volatile int writeHandlersCounter;
     protected final Queue<WriteHandler> writeHandlersQueue =
-            new ConcurrentLinkedQueue<WriteHandler>();
+            new ConcurrentLinkedQueue<>();
     // ------------------------------------------------------------ Constructors
 
 
     protected TaskQueue(final MutableMaxQueueSize maxQueueSizeHolder) {
         this.maxQueueSizeHolder = maxQueueSizeHolder;
-        queue = new ConcurrentLinkedQueue<E>();
+        queue = new ConcurrentLinkedQueue<>();
     }
 
     // ---------------------------------------------------------- Public Methods
@@ -66,7 +66,7 @@ public final class TaskQueue<E extends AsyncQueueRecord> {
 
     public static <E extends AsyncQueueRecord> TaskQueue<E> createTaskQueue(
             final MutableMaxQueueSize maxQueueSizeHolder) {
-        return new TaskQueue<E>(maxQueueSizeHolder);
+        return new TaskQueue<>(maxQueueSizeHolder);
     }
 
     /**
@@ -89,7 +89,7 @@ public final class TaskQueue<E extends AsyncQueueRecord> {
     @SuppressWarnings("unchecked")
     public E poll() {
         E current = (E) currentElementUpdater.getAndSet(this, null);
-        return current != null ? current : queue.poll();
+        return current == null ? queue.poll() : current;
     }
 
     /**
@@ -99,7 +99,7 @@ public final class TaskQueue<E extends AsyncQueueRecord> {
      * from the queue using {@link #setCurrentElement(org.glassfish.grizzly.asyncqueue.AsyncQueueRecord)}
      * and passing <tt>null</tt> as a parameter, this is a little bit more optimal
      * alternative to {@link #poll()}.
-     * 
+     *
      * @return the current processing task
      */
     public E peek() {
@@ -110,16 +110,16 @@ public final class TaskQueue<E extends AsyncQueueRecord> {
                 currentElement = current;
             }
         }
-        
+
         if (current != null &&
                 isClosed && currentElementUpdater.compareAndSet(this, current, null)) {
             current.notifyFailure(new IOException("Connection closed"));
             return null;
         }
-        
+
         return current;
     }
-    
+
     /**
      * Reserves memory space in the queue.
      *
@@ -152,10 +152,10 @@ public final class TaskQueue<E extends AsyncQueueRecord> {
         doNotify();
         return space;
     }
-    
+
     /**
      * Returns the number of queued bytes.
-     * 
+     *
      * @return the number of queued bytes.
      */
     public int spaceInBytes() {
@@ -173,30 +173,30 @@ public final class TaskQueue<E extends AsyncQueueRecord> {
     public void notifyWritePossible(final WriteHandler writeHandler) {
         notifyWritePossible(writeHandler, maxQueueSizeHolder.getMaxQueueSize());
     }
-    
+
     public void notifyWritePossible(final WriteHandler writeHandler, final int maxQueueSize) {
-        
+
         if (writeHandler == null) {
             return;
         }
-        
+
         if (isClosed) {
             writeHandler.onError(new IOException("Connection is closed"));
             return;
         }
-        
+
         if (maxQueueSize < 0 || spaceInBytes() < maxQueueSize) {
             try {
                 writeHandler.onWritePossible();
             } catch (Throwable e) {
                 writeHandler.onError(e);
             }
-            
+
             return;
         }
-        
+
         offerWriteHandler(writeHandler);
-        
+
         if (spaceInBytes() < maxQueueSize && removeWriteHandler(writeHandler)) {
             try {
                 writeHandler.onWritePossible();
@@ -208,32 +208,30 @@ public final class TaskQueue<E extends AsyncQueueRecord> {
         }
     }
 
-    public final boolean forgetWritePossible(final WriteHandler writeHandler) {
+    public boolean forgetWritePossible(final WriteHandler writeHandler) {
         return removeWriteHandler(writeHandler);
     }
-    
+
     private void checkWriteHandlerOnClose(final WriteHandler writeHandler) {
         if (isClosed && removeWriteHandler(writeHandler)) {
             writeHandler.onError(new IOException("Connection is closed"));
         }
     }
-    // ------------------------------------------------------- Protected Methods
 
-
+    /**
+     * Notifies processing the queue by write handlers.
+     */
     public void doNotify() {
-        if (maxQueueSizeHolder == null ||
-                writeHandlersCounter == 0) {
+        if (maxQueueSizeHolder == null || writeHandlersCounter == 0) {
             return;
         }
-        
+
         final int maxQueueSize = maxQueueSizeHolder.getMaxQueueSize();
-        
         while (spaceInBytes() < maxQueueSize) {
-            WriteHandler writeHandler = pollWriteHandler();
+            final WriteHandler writeHandler = pollWriteHandler();
             if (writeHandler == null) {
                 return;
             }
-            
             try {
                 writeHandler.onWritePossible();
             } catch (Throwable e) {
@@ -241,14 +239,14 @@ public final class TaskQueue<E extends AsyncQueueRecord> {
             }
         }
     }
-    
+
     /**
      * Set current task element.
      * @param task current element.
      */
     public void setCurrentElement(final E task) {
         currentElement = task;
-        
+
         if (task != null && isClosed &&
                 currentElementUpdater.compareAndSet(this, task, null)) {
             task.notifyFailure(new IOException("Connection closed"));
@@ -262,10 +260,10 @@ public final class TaskQueue<E extends AsyncQueueRecord> {
                 newValue.notifyFailure(new IOException("Connection closed"));
                 return false;
             }
-            
+
             return true;
         }
-        
+
         return false;
     }
 
@@ -277,7 +275,7 @@ public final class TaskQueue<E extends AsyncQueueRecord> {
     public boolean remove(final E task) {
         return queue.remove(task);
     }
-    
+
     /**
      * Add the new task into the task queue.
      *
@@ -289,8 +287,8 @@ public final class TaskQueue<E extends AsyncQueueRecord> {
             task.notifyFailure(new IOException("Connection closed"));
         }
     }
-    
-    public boolean isEmpty() {        
+
+    public boolean isEmpty() {
         return spaceInBytes == 0;
     }
 
@@ -300,19 +298,19 @@ public final class TaskQueue<E extends AsyncQueueRecord> {
 
     public void onClose(final Throwable cause) {
         isClosed = true;
-        
+
         IOException error = null;
         if (!isEmpty()) {
             if (error == null) {
                 error = new IOException("Connection closed", cause);
             }
-            
+
             AsyncQueueRecord record;
             while ((record = poll()) != null) {
                 record.notifyFailure(error);
             }
         }
-        
+
         WriteHandler writeHandler;
         while ((writeHandler = pollWriteHandler()) != null) {
             if (error == null) {
@@ -321,18 +319,18 @@ public final class TaskQueue<E extends AsyncQueueRecord> {
             writeHandler.onError(error);
         }
     }
-    
+
     private void offerWriteHandler(final WriteHandler writeHandler) {
         writeHandlersCounterUpdater.incrementAndGet(this);
         writeHandlersQueue.offer(writeHandler);
     }
-    
+
     private boolean removeWriteHandler(final WriteHandler writeHandler) {
         if (writeHandlersQueue.remove(writeHandler)) {
             writeHandlersCounterUpdater.decrementAndGet(this);
             return true;
         }
-        
+
         return false;
     }
 
@@ -342,12 +340,12 @@ public final class TaskQueue<E extends AsyncQueueRecord> {
             writeHandlersCounterUpdater.decrementAndGet(this);
             return record;
         }
-        
+
         return null;
     }
-    
+
     //----------------------------------------------------------- Nested Classes
-    
+
     public interface MutableMaxQueueSize {
         int getMaxQueueSize();
     }

--- a/modules/http-ajp/pom.xml
+++ b/modules/http-ajp/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-ajp</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>grizzly-http-ajp</name>
     <url>https://projects.eclipse.org/projects/ee4j.grizzly</url>
     <build>

--- a/modules/http-server/pom.xml
+++ b/modules/http-server/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-server</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>grizzly-http-server</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/http-servlet/pom.xml
+++ b/modules/http-servlet/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-servlet</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>grizzly-http-servlet</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/http/pom.xml
+++ b/modules/http/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>grizzly-http</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/io/OutputBuffer.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/io/OutputBuffer.java
@@ -39,6 +39,7 @@ import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.glassfish.grizzly.Buffer;
+import org.glassfish.grizzly.CloseReason;
 import org.glassfish.grizzly.CompletionHandler;
 import org.glassfish.grizzly.Connection;
 import org.glassfish.grizzly.FileTransfer;
@@ -849,9 +850,15 @@ public class OutputBuffer {
         if (this.handler != null) {
             throw new IllegalStateException("Illegal attempt to set a new handler before the existing handler has been notified.");
         }
-        
-        if (!httpContext.getCloseable().isOpen()) {
-            handler.onError(connection.getCloseReason().getCause());
+
+        if (handler != null && !httpContext.getCloseable().isOpen()) {
+            final CloseReason closeReason = connection.getCloseReason();
+            if (closeReason == null) {
+                LOGGER.log(Level.WARNING, "No close reason set, using default: {0}", CloseReason.LOCALLY_CLOSED_REASON);
+                handler.onError(CloseReason.LOCALLY_CLOSED_REASON.getCause());
+            } else {
+                handler.onError(closeReason.getCause());
+            }
             return;
         }
 
@@ -879,6 +886,7 @@ public class OutputBuffer {
             // have been processed by WriteHandler.onError().
             httpContext.getOutputSink().notifyCanWrite(asyncWriteHandler);
         } catch (Exception ignored) {
+            LOGGER.log(Level.FINE, "Ignoring exception.", ignored);
         }
     }
 

--- a/modules/http2/pom.xml
+++ b/modules/http2/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/DefaultInputBuffer.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/DefaultInputBuffer.java
@@ -43,41 +43,41 @@ import static org.glassfish.grizzly.http2.Termination.IN_FIN_TERMINATION;
  */
 class DefaultInputBuffer implements StreamInputBuffer {
     private static final Logger LOGGER = Grizzly.logger(StreamInputBuffer.class);
-    
+
     private static final long NULL_CONTENT_LENGTH = Long.MIN_VALUE;
-    
+
     private static final AtomicIntegerFieldUpdater<DefaultInputBuffer> inputQueueSizeUpdater =
-            AtomicIntegerFieldUpdater.newUpdater(DefaultInputBuffer.class, "inputQueueSize");            
-    @SuppressWarnings("unused")
+            AtomicIntegerFieldUpdater.newUpdater(DefaultInputBuffer.class, "inputQueueSize");
+
     private volatile int inputQueueSize;
 
     private final BlockingQueue<InputElement> inputQueue = new LinkedTransferQueue<>();
 
     // true, if the input is closed
     private final AtomicBoolean inputClosed = new AtomicBoolean();
-    
+
     // the termination flag. When is not null contains the reason why input was terminated.
     // when the flag is not null - poll0() will return -1.
     private static final AtomicReferenceFieldUpdater<DefaultInputBuffer, Termination> closeFlagUpdater =
             AtomicReferenceFieldUpdater.newUpdater(DefaultInputBuffer.class, Termination.class, "closeFlag");
     @SuppressWarnings("unused")
     private volatile Termination closeFlag;
-    
+
     private final Object terminateSync = new Object();
-    
+
     private final Http2Stream stream;
     private final Http2Session http2Session;
-    
+
     private final Object expectInputSwitchSync = new Object();
     private boolean expectInputSwitch;
-    
+
     private long remainingContentLength = NULL_CONTENT_LENGTH;
-    
+
     DefaultInputBuffer(final Http2Stream stream) {
         this.stream = stream;
         http2Session = stream.getHttp2Session();
     }
-    
+
     /**
      * The method will be invoked once upstream completes READ operation processing.
      * Here we have to simulate NIO OP_READ event re-registration.
@@ -89,19 +89,19 @@ class DefaultInputBuffer implements StreamInputBuffer {
                 !stream.getInputHttpHeader().isExpectContent()) {
             return;
         }
-        
+
         // If input stream has been terminated - send error message upstream
         if (isClosed()) {
             http2Session.sendMessageUpstream(stream,
                     buildBrokenHttpContent(
                         new EOFException(closeFlag.getDescription())));
-            
+
             return;
         }
-        
+
         // Switch on the "expect more input" flag
         switchOnExpectInput();
-        
+
         // Check if we have more input data to process - try to obtain the
         // expectInputSwitch again and process data
         final int queueSize;
@@ -109,7 +109,7 @@ class DefaultInputBuffer implements StreamInputBuffer {
             passPayloadUpstream(null, queueSize);
         }
     }
-    
+
     /**
      * The method is called, when new input data arrives.
      */
@@ -118,7 +118,7 @@ class DefaultInputBuffer implements StreamInputBuffer {
         if (inputClosed.get()) {
             // if input is closed - just ignore the message
             data.tryDispose();
-            
+
             return false;
         }
 
@@ -127,24 +127,24 @@ class DefaultInputBuffer implements StreamInputBuffer {
                     new Object[]{stream.getId(), data, isLast});
         }
         final boolean isLastData = isLast | checkContentLength(data.remaining());
-        
+
         // create InputElement and add it to the input queue
         // we double check if this is the last frame (considering content-length header if any)
         final InputElement element = new InputElement(data, isLastData, false);
         offer0(element);
-        
+
         if (isLastData) {
             // mark the input buffer as closed
             inputClosed.set(true);
         }
-        
+
         // if the stream had been terminated by this time but the element wasn't
         // read - dispose the buffer and return false
         if (isClosed() && inputQueue.remove(element)) {
             data.tryDispose();
             return false;
         }
-        
+
         return true;
     }
 
@@ -176,25 +176,25 @@ class DefaultInputBuffer implements StreamInputBuffer {
 
     /**
      * Sends the available input data upstream.
-     * 
+     *
      * @param inputElement {@link InputElement} element to be appended to the current input queue content and sent upstream
      * @param readyBuffersCount the current input queue size (-1 if we don't have this information at the moment).
      */
     private void passPayloadUpstream(final InputElement inputElement,
             int readyBuffersCount) {
-        
+
         try {
             if (readyBuffersCount == -1) {
                 readyBuffersCount = inputQueueSize;
             }
-            
+
             Buffer payload = null;
             if (readyBuffersCount > 0) {
                 // if the input queue is not empty - get its elements
                 payload = poll0();
                 assert payload != null;
             }
-            
+
             if (inputElement != null) {
                 // if extra input element is not null - try to append it
                 final Buffer data = inputElement.toBuffer();
@@ -203,17 +203,17 @@ class DefaultInputBuffer implements StreamInputBuffer {
                     // append input queue and extra input element contents
                     payload = Buffers.appendBuffers(http2Session.getMemoryManager(),
                             payload, data);
-                    
+
                     // notify peer that data.remaining() has been read (update window)
                     http2Session.ackConsumedData(stream, bufSz(data));
                 } else if (payload == null) {
                     payload = data;
                 }
-                
+
                 // check if the extra input element is EOF
                 checkEOF(inputElement);
             }
-            
+
             // build HttpContent based on payload
             final HttpContent content = buildHttpContent(payload);
             // send it upstream
@@ -223,24 +223,24 @@ class DefaultInputBuffer implements StreamInputBuffer {
             LOGGER.log(Level.WARNING, "Unexpected IOException: {0}", e.getMessage());
         }
     }
-    
+
     /**
      * Retrieves available input buffer payload, waiting up to the
      * {@link Connection#getReadTimeout(java.util.concurrent.TimeUnit)}
      * wait time if necessary for payload to become available.
-     * 
+     *
      * @throws IOException if an error occurs with the poll operation.
      */
     @Override
     public HttpContent poll() throws IOException {
         return buildHttpContent(poll0());
     }
-    
+
     /**
      * Retrieves available input buffer payload, waiting up to the
      * {@link Connection#getReadTimeout(java.util.concurrent.TimeUnit)}
      * wait time if necessary for payload to become available.
-     * 
+     *
      * @throws IOException if an error occurs with the poll operation.
      */
     private Buffer poll0() throws IOException {
@@ -248,7 +248,7 @@ class DefaultInputBuffer implements StreamInputBuffer {
             // if input is terminated - return empty buffer
             return Buffers.EMPTY_BUFFER;
         }
-        
+
         Buffer buffer;
         synchronized (terminateSync) { // most of the time it will be uncontended sync
             InputElement inputElement;
@@ -269,17 +269,16 @@ class DefaultInputBuffer implements StreamInputBuffer {
                 if (inputElement == null) {
                     // timeout expired
                     throw new IOException("Blocking read timeout");
-                } else {
-                    // Due to asynchronous inputQueueSize update - the inputQueueSizeNow may be < 0.
-                    // It means the inputQueueSize.getAndSet(0); above, may unintentionally increase the counter.
-                    // So, once we read a Buffer - we have to properly restore the counter value.
-                    // Normally it had to be inputQueueSize.decrementAndGet(); , but we have to
-                    // take into account fact described above.
-                    inputQueueSizeUpdater.addAndGet(this, inputQueueSizeNow - 1);
-
-                    checkEOF(inputElement);
-                    buffer = inputElement.toBuffer();
                 }
+                // Due to asynchronous inputQueueSize update - the inputQueueSizeNow may be < 0.
+                // It means the inputQueueSize.getAndSet(0); above, may unintentionally increase the counter.
+                // So, once we read a Buffer - we have to properly restore the counter value.
+                // Normally it had to be inputQueueSize.decrementAndGet(); , but we have to
+                // take into account fact described above.
+                inputQueueSizeUpdater.addAndGet(this, inputQueueSizeNow - 1);
+
+                checkEOF(inputElement);
+                buffer = inputElement.toBuffer();
             } else if (inputQueueSizeNow == 1) {
                 // if there is one element available
                 inputElement = inputQueue.poll();
@@ -309,22 +308,21 @@ class DefaultInputBuffer implements StreamInputBuffer {
                 buffer = compositeBuffer;
             }
         }
-        
+
         // send window_update notification
         http2Session.ackConsumedData(stream, bufSz(buffer));
 
         return buffer;
-    }    
+    }
 
     /**
      * Graceful input buffer close.
-     * 
+     *
      * Marks the input buffer as closed by adding Termination input element to the input queue.
      */
     @Override
     public void close(final Termination termination) {
         if (inputClosed.compareAndSet(false, true)) {
-            final Termination.TerminationType type = termination.getType();
             if (termination.isSessionClosed()) {
                 return;
             }
@@ -334,22 +332,21 @@ class DefaultInputBuffer implements StreamInputBuffer {
 
     /**
      * Forcibly closes the input buffer.
-     * 
+     *
      * All the buffered data will be discarded.
      */
     @Override
     public void terminate(final Termination termination) {
         final boolean isSet = closeFlagUpdater.compareAndSet(this, null, termination);
-        
+
         if (inputClosed.compareAndSet(false, true)) {
-            final Termination.TerminationType type = termination.getType();
             if (!termination.isSessionClosed()) {
                 offer0(new InputElement(termination, true, true));
             }
         }
-        
+
         if (isSet) {
-            
+
             int szToRelease = 0;
             synchronized (terminateSync) {
                 // remove all elements from the queue,
@@ -357,7 +354,7 @@ class DefaultInputBuffer implements StreamInputBuffer {
                 // release correspondent number of bytes in the session
                 // control flow window
                 InputElement element;
-                
+
                 while ((element = inputQueue.poll()) != null) {
                     if (!element.isService) {
                         final Buffer buffer = element.toBuffer();
@@ -366,15 +363,15 @@ class DefaultInputBuffer implements StreamInputBuffer {
                     }
                 }
             }
-            
+
             if (szToRelease > 0) {
                 http2Session.ackConsumedData(szToRelease);
             }
-            
+
             stream.onInputClosed();
         }
     }
-    
+
     /**
      * Returns <tt>true</tt> if the <tt>InputBuffer</tt> has been closed.
      */
@@ -382,7 +379,7 @@ class DefaultInputBuffer implements StreamInputBuffer {
     public boolean isClosed() {
         return closeFlag != null;
     }
-    
+
     /**
      * Checks if the passed InputElement is input buffer EOF element.
      * @param inputElement the {@link InputElement} to check EOF status against.
@@ -390,11 +387,11 @@ class DefaultInputBuffer implements StreamInputBuffer {
     private void checkEOF(final InputElement inputElement) {
         // first of all it has to be the last element
         if (inputElement.isLast) {
-            
+
             final Termination termination = !inputElement.isService
                                       ? IN_FIN_TERMINATION
                                       : (Termination) inputElement.content;
-            
+
             if (closeFlagUpdater.compareAndSet(this, null, termination)) {
 
                 // Let termination run some logic if needed.
@@ -409,7 +406,7 @@ class DefaultInputBuffer implements StreamInputBuffer {
     /**
      * Based on content-length header (which we may have or may not), double
      * check if the payload we've just got is last.
-     * 
+     *
      * @param newDataChunkSize the number of bytes we've just got.
      * @return <tt>true</tt> if we don't expect more content, or <tt>false</tt> if
      * we do expect more content or we're not sure because content-length header
@@ -419,7 +416,7 @@ class DefaultInputBuffer implements StreamInputBuffer {
         if (remainingContentLength == NULL_CONTENT_LENGTH) {
             remainingContentLength = stream.getInputHttpHeader().getContentLength();
         }
-        
+
         if (remainingContentLength >= 0) {
             remainingContentLength -= newDataChunkSize;
             if (remainingContentLength == 0) {
@@ -430,7 +427,7 @@ class DefaultInputBuffer implements StreamInputBuffer {
                         ": peer is sending data beyond specified content-length limit");
             }
         }
-        
+
         return false;
     }
 
@@ -440,7 +437,7 @@ class DefaultInputBuffer implements StreamInputBuffer {
                 expectInputSwitch = false;
                 return true;
             }
-            
+
             return false;
         }
     }
@@ -452,7 +449,7 @@ class DefaultInputBuffer implements StreamInputBuffer {
                 expectInputSwitch = false;
                 return queueSize;
             }
-            
+
             return 0;
         }
     }
@@ -462,7 +459,7 @@ class DefaultInputBuffer implements StreamInputBuffer {
             expectInputSwitch = true;
         }
     }
-    
+
     /**
      * Builds {@link HttpContent} based on passed payload {@link Buffer}.
      * If the payload size is <tt>0</tt> and the input buffer has been terminated -
@@ -471,13 +468,13 @@ class DefaultInputBuffer implements StreamInputBuffer {
     private HttpContent buildHttpContent(final Buffer payload) {
         final Termination localTermination = closeFlag;
         final boolean isFin = localTermination == IN_FIN_TERMINATION;
-        
+
         final HttpContent httpContent;
-        
+
         // if payload size is not 0 or this is FIN payload
         if (payload.hasRemaining() || localTermination == null || isFin) {
             final HttpHeader inputHttpHeader = stream.getInputHttpHeader();
-            
+
             inputHttpHeader.setExpectContent(!isFin);
             httpContent = HttpContent.builder(inputHttpHeader)
                     .content(payload)
@@ -488,7 +485,7 @@ class DefaultInputBuffer implements StreamInputBuffer {
             httpContent = buildBrokenHttpContent(
                     new EOFException(localTermination.getDescription()));
         }
-        
+
         return httpContent;
     }
 
@@ -502,14 +499,14 @@ class DefaultInputBuffer implements StreamInputBuffer {
     private static int bufSz(final Buffer buffer) {
         return buffer != null ? buffer.remaining() : 0;
     }
-    
+
     /**
      * Class represent input queue element
      */
     private static final class InputElement {
         private final Object content;
         private final boolean isLast;
-        
+
         private final boolean isService;
 
         public InputElement(final Object content, final boolean isLast,
@@ -518,7 +515,7 @@ class DefaultInputBuffer implements StreamInputBuffer {
             this.isLast = isLast;
             this.isService = isService;
         }
-        
+
         private Buffer toBuffer() {
             return !isService ? (Buffer) content : Buffers.EMPTY_BUFFER;
         }

--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/DefaultOutputSink.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/DefaultOutputSink.java
@@ -274,7 +274,7 @@ class DefaultOutputSink implements StreamOutputSink {
                 http2Session.getDeflaterLock().lock();
                 lockedByMe = true;
                 final boolean logging = NetLogger.isActive();
-                final Map<String,String> capture = ((logging) ? new HashMap<>() : null);
+                final Map<String,String> capture = logging ? new HashMap<>() : null;
                 headerFrames = http2Session.encodeHttpHeaderAsHeaderFrames(
                         ctx, httpHeader, stream.getId(), dontSendPayload, null, capture);
                 if (logging) {

--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/DefaultOutputSink.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/DefaultOutputSink.java
@@ -262,7 +262,6 @@ class DefaultOutputSink implements StreamOutputSink {
         boolean sendTrailers = false;
         boolean lockedByMe = false;
         try {
-            // try-finally block to release deflater lock if needed
             boolean isLast = httpContent != null && httpContent.isLast();
             final boolean isTrailer = HttpTrailer.isTrailer(httpContent);
 
@@ -345,10 +344,15 @@ class DefaultOutputSink implements StreamOutputSink {
                     isLast, isZeroSizeData);
                 outputQueue.offer(record);
 
-                // check if our element wasn't forgotten (async)
-                if (outputQueue.size() != spaceToReserve || !outputQueue.remove(record)) {
-                    sendTrailers = false; // isLast && isTrailer; // FIXME: this causes data corruption!
-                    LOGGER.finest("Weird condition. FIXME... why are we removing what we added in previous if/else?");
+                // there is yet something in the queue before current record
+                if (outputQueue.size() != spaceToReserve) {
+                    sendTrailers = isLast && isTrailer;
+                    return null;
+                }
+                //
+                if (!outputQueue.remove(record)) {
+                    sendTrailers = false;
+                    LOGGER.finest("The record has been already processed.");
                     return null;
                 }
             }

--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2BaseFilter.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2BaseFilter.java
@@ -71,11 +71,11 @@ import org.glassfish.grizzly.http2.frames.PriorityFrame;
  * The {@link org.glassfish.grizzly.filterchain.Filter} serves as a bridge
  * between HTTP2 frames and upper-level HTTP layers by converting {@link Http2Frame}s into
  * {@link HttpPacket}s and passing them up/down by the {@link FilterChain}.
- * 
+ *
  * Additionally this {@link org.glassfish.grizzly.filterchain.Filter} has
  * logic responsible for checking HTTP2 protocol semantics and fire correspondent
  * events and messages in case when HTTP2 semantics is broken.
- * 
+ *
  * @author Grizzly team
  */
 public abstract class Http2BaseFilter extends HttpBaseFilter {
@@ -90,18 +90,18 @@ public abstract class Http2BaseFilter extends HttpBaseFilter {
      * Attribute name for associating push status.
      */
     static final String HTTP2_PUSH_ENABLED = "http2-push-enabled";
-    
+
     static final byte[] PRI_PAYLOAD = "SM\r\n\r\n".getBytes(Charsets.ASCII_CHARSET);
-    
+
     protected static final TransferEncoding FIXED_LENGTH_ENCODING =
             new FixedLengthTransferEncoding();
 
     final Http2FrameCodec frameCodec = new Http2FrameCodec();
 
     private final Http2Configuration configuration;
-    
+
     protected final ExecutorService threadPool;
-    
+
     private int localMaxFramePayloadSize;
 
     /**
@@ -140,7 +140,7 @@ public abstract class Http2BaseFilter extends HttpBaseFilter {
     protected boolean processFrames(final FilterChainContext ctx,
             final Http2Session http2Session,
             final List<Http2Frame> framesList) {
-        
+
         if (framesList == null || framesList.isEmpty()) {
             return true;
         }
@@ -163,8 +163,7 @@ public abstract class Http2BaseFilter extends HttpBaseFilter {
                             throw new Http2SessionException(ErrorCode.PROTOCOL_ERROR);
                         }
 
-                        sendRstStream(ctx, http2Session,
-                                streamId, e.getErrorCode());
+                        sendRstStream(ctx, http2Session, streamId, e.getErrorCode());
                     }
                 }
             } finally {
@@ -172,101 +171,100 @@ public abstract class Http2BaseFilter extends HttpBaseFilter {
                 framesList.clear();
             }
 
-            final List<Http2Stream> streamsToFlushInput =
-                    http2Session.streamsToFlushInput;
+            final List<Http2Stream> streamsToFlushInput = http2Session.streamsToFlushInput;
             for (Http2Stream streamsToFlush : streamsToFlushInput) {
                 streamsToFlush.flushInputData();
             }
             streamsToFlushInput.clear();
-            
+
             return true;
         } catch (Http2SessionException e) {
             if (LOGGER.isLoggable(Level.FINE)) {
                 LOGGER.log(Level.FINE, "Http2SessionException occurred on connection=" +
-                        ctx.getConnection() + " during Http2Frame processing", e);
+                    ctx.getConnection() + " during Http2Frame processing", e);
             }
             http2Session.terminate(e.getErrorCode(), e.getMessage());
         } catch (IOException e) {
             if (LOGGER.isLoggable(Level.FINE)) {
                 LOGGER.log(Level.FINE, "IOException occurred on connection=" +
-                        ctx.getConnection() + " during Http2Frame processing", e);
+                    ctx.getConnection() + " during Http2Frame processing", e);
             }
             http2Session.terminate(ErrorCode.INTERNAL_ERROR, e.getMessage());
         }
-        
+
         return false;
     }
 
     protected boolean checkRequestHeadersOnUpgrade(
             final HttpRequestPacket httpRequest) {
-        
+
         if (!httpRequest.isUpgrade()) {
             if (LOGGER.isLoggable(Level.FINEST)) {
                 LOGGER.finest("checkRequestHeadersOnUpgrade: failed no upgrade");
             }
             return false;
         }
-        
+
         // Check "Connection: Upgrade, HTTP2-Settings" header
         final DataChunk connectionHeaderDC =
                 httpRequest.getHeaders().getValue(Header.Connection);
-        
+
         if (connectionHeaderDC == null) {
             if (LOGGER.isLoggable(Level.FINEST)) {
                 LOGGER.finest("checkRequestHeadersOnUpgrade: failed no connection");
             }
             return false;
         }
-        
+
         boolean upgradeFound = false;
         boolean http2SettingsFound = false;
-        
+
         int pos = 0;
         final int len = connectionHeaderDC.getLength();
         while (pos < len) {
             final int comma = connectionHeaderDC.indexOf(",", pos);
             final int valueEnd = comma != -1 ? comma : len;
-            
+
             final String value = connectionHeaderDC.toString(pos, valueEnd).trim();
-            
+
             upgradeFound = upgradeFound || "Upgrade".equals(value);
             http2SettingsFound = http2SettingsFound || "HTTP2-Settings".equals(value);
-            
+
             pos = valueEnd + 1;
         }
-        
+
         if (!upgradeFound || !http2SettingsFound) {
             if (LOGGER.isLoggable(Level.FINEST)) {
                 LOGGER.log(Level.FINEST, "checkRequestHeadersOnUpgrade: failed incorrect connection: {0}", connectionHeaderDC);
             }
             return false;
         }
-        
+
         // Check Http2-Settings header
-        
+
         if (!httpRequest.getHeaders().contains(Header.HTTP2Settings)) {
             if (LOGGER.isLoggable(Level.FINEST)) {
                 LOGGER.finest("checkRequestHeadersOnUpgrade: failed no settings");
             }
             return false;
         }
-        
+
         return true;
     }
-    
+
     protected boolean checkResponseHeadersOnUpgrade(
             final HttpResponsePacket httpResponse) {
-        
+
         if (httpResponse.getStatus() != 101) {
             // Not "HTTP/1.1 101 Switching Protocols"
             return false;
         }
-        
+
         if (!httpResponse.isUpgrade()) {
             // No Upgrade header
             return false;
         }
-        
+
         // Check "Connection: Upgrade, HTTP2-Settings" header
         final DataChunk connectionHeaderDC =
                 httpResponse.getHeaders().getValue(Header.Connection);
@@ -275,28 +273,28 @@ public abstract class Http2BaseFilter extends HttpBaseFilter {
                 !connectionHeaderDC.equals(Header.Upgrade.getBytes()));
 
     }
-    
+
     protected SettingsFrame getHttp2UpgradeSettings(
             final HttpRequestPacket httpRequest) {
-        
+
         final DataChunk http2Settings =
                 httpRequest.getHeaders().getValue(Header.HTTP2Settings);
-        
+
         return http2Settings != null
                 ? SettingsFrame.fromBase64Uri(http2Settings)
                 : null;
     }
-    
+
     protected boolean isHttp2UpgradingVersion(
             final HttpHeader httpHeader) {
         final DataChunk upgradeDC= httpHeader.getUpgradeDC();
 
         assert upgradeDC != null && !upgradeDC.isNull(); // should've been check before
-        
+
         // Check "Upgrade: h2c" header
         return upgradeDC.equals(HTTP2_CLEAR);
     }
-    
+
     // ------------------------------------------------------- Protected Methods
 
 
@@ -393,7 +391,7 @@ public abstract class Http2BaseFilter extends HttpBaseFilter {
 
 
     // --------------------------------------------------------- Private Methods
-    
+
     @SuppressWarnings("DuplicateThrows")
     private void processInFrame(final Http2Session http2Session,
                                 final FilterChainContext context,
@@ -468,7 +466,7 @@ public abstract class Http2BaseFilter extends HttpBaseFilter {
 
     private void processWindowUpdateFrame(final Http2Session http2Session,
             final Http2Frame frame) throws Http2StreamException, Http2SessionException {
-        
+
         WindowUpdateFrame updateFrame = (WindowUpdateFrame) frame;
         final int streamId = updateFrame.getStreamId();
         final int delta = updateFrame.getWindowSizeIncrement();
@@ -506,7 +504,7 @@ public abstract class Http2BaseFilter extends HttpBaseFilter {
         http2Session.setGoAwayByPeer(((GoAwayFrame) frame).getLastStreamId());
         frame.recycle();
     }
-    
+
     private void processSettingsFrame(final Http2Session http2Session,
             final FilterChainContext context, final Http2Frame frame)
     throws Http2SessionException, Http2StreamException {
@@ -533,16 +531,16 @@ public abstract class Http2BaseFilter extends HttpBaseFilter {
         } finally {
             frame.recycle();
         }
-        
+
 
     }
-    
+
     void applySettings(final Http2Session http2Session, final SettingsFrame settingsFrame)
     throws Http2SessionException, Http2StreamException {
 
         for (int i = 0, numberOfSettings = settingsFrame.getNumberOfSettings(); i < numberOfSettings; i++) {
             final SettingsFrame.Setting setting = settingsFrame.getSettingByIndex(i);
-            
+
             switch (setting.getId()) {
                 case SettingsFrame.SETTINGS_HEADER_TABLE_SIZE:
                     break;
@@ -624,11 +622,11 @@ public abstract class Http2BaseFilter extends HttpBaseFilter {
         if (stream.isIdle()) {
             throw new Http2SessionException(ErrorCode.PROTOCOL_ERROR, "Illegal attempt to RST IDLE stream.");
         }
-        
+
         // Notify the stream that it has been reset remotely
         stream.resetRemotely();
     }
-    
+
     private void processHeadersFrame(final Http2Session http2Session,
                                   final FilterChainContext context,
                                   final Http2Frame frame) throws IOException {
@@ -654,7 +652,7 @@ public abstract class Http2BaseFilter extends HttpBaseFilter {
         }
 
         final HeadersDecoder headersDecoder = http2Session.getHeadersDecoder();
-        
+
         if (headerBlockFragment.getCompressedHeaders().hasRemaining()) {
             if (!headersDecoder.append(headerBlockFragment.takePayload())) {
                 headersDecoder.setFirstHeaderFrame((HeaderBlockHead) headerBlockFragment);
@@ -672,17 +670,17 @@ public abstract class Http2BaseFilter extends HttpBaseFilter {
         }
 
         final boolean isEOH = headerBlockFragment.isEndHeaders();
-        
+
         if (!headersDecoder.isProcessingHeaders()) { // first headers frame (either HeadersFrame or PushPromiseFrame)
             headersDecoder.setFirstHeaderFrame((HeaderBlockHead) headerBlockFragment);
         } else {
             headerBlockFragment.recycle();
         }
-        
+
         if (!isEOH) {
             return; // wait for more header frames to come
         }
-        
+
         final HeaderBlockHead firstHeaderFrame =
                 headersDecoder.finishHeader();
 
@@ -695,7 +693,7 @@ public abstract class Http2BaseFilter extends HttpBaseFilter {
 
     /**
      * The method is called once complete HTTP header block arrives on {@link Http2Session}.
-     * 
+     *
      * @param http2Session the {@link Http2Session} associated with this header.
      * @param context the current {@link FilterChainContext}
      * @param firstHeaderFrame the first {@link HeaderBlockHead} from the first {@link HeadersFrame} received.
@@ -710,13 +708,13 @@ public abstract class Http2BaseFilter extends HttpBaseFilter {
     @SuppressWarnings("unchecked")
     public NextAction handleWrite(final FilterChainContext ctx) throws IOException {
         final Http2State http2State = Http2State.get(ctx.getConnection());
-        
+
         if (http2State == null || http2State.isNeverHttp2()) {
             return ctx.getInvokeAction();
         }
-        
+
         final Object message = ctx.getMessage();
-        
+
         final Http2Session http2Session = obtainHttp2Session(ctx, false);
 
         if (http2Session.isHttp2OutputEnabled() &&
@@ -741,20 +739,20 @@ public abstract class Http2BaseFilter extends HttpBaseFilter {
             final Http2Session http2Session,
             final HttpHeader httpHeader,
             final HttpPacket entireHttpPacket) throws IOException;
-    
+
 
     protected void prepareOutgoingRequest(final HttpRequestPacket request) {
         String contentType = request.getContentType();
         if (contentType != null) {
             request.getHeaders().setValue(Header.ContentType).setString(contentType);
         }
-        
+
         if (request.getContentLength() != -1) {
             // FixedLengthTransferEncoding will set proper Content-Length header
             FIXED_LENGTH_ENCODING.prepareSerialize(null, request, null);
         }
-    }    
-    
+    }
+
     @Override
     @SuppressWarnings("unchecked")
     public NextAction handleEvent(final FilterChainContext ctx,
@@ -762,23 +760,23 @@ public abstract class Http2BaseFilter extends HttpBaseFilter {
         if (!Http2State.isHttp2(ctx.getConnection())) {
             return ctx.getInvokeAction();
         }
-        
+
         final Object type = event.type();
-        
+
         if (type == TransportFilter.FlushEvent.TYPE) {
             assert event instanceof TransportFilter.FlushEvent;
-            
+
             final HttpContext httpContext = HttpContext.get(ctx);
             final Http2Stream stream = (Http2Stream) httpContext.getContextStorage();
-            
+
             final TransportFilter.FlushEvent flushEvent =
                     (TransportFilter.FlushEvent) event;
-            
+
             stream.outputSink.flush(flushEvent.getCompletionHandler());
-            
+
             return ctx.getStopAction();
         }
-        
+
         return ctx.getInvokeAction();
     }
 
@@ -792,18 +790,18 @@ public abstract class Http2BaseFilter extends HttpBaseFilter {
             final Http2Stream http2Stream =
                     (Http2Stream) HttpContext.get(ctx).getContextStorage();
             ctx.setMessage(http2Stream.pollInputData());
-            
+
             return true;
         }
-        
+
         final HttpContent httpContent = (HttpContent) message;
         final HttpHeader httpHeader = httpContent.getHttpHeader();
-        
+
         // if the stream is assigned - it means we process HTTP/2.0 request
         // in the upstream (HTTP2 stream chain)
         return Http2Stream.getStreamFor(httpHeader) != null;
     }
-    
+
     /**
      * Creates {@link Http2Session} with pre-configured initial-windows-size and
      * max-concurrent-streams
@@ -813,7 +811,7 @@ public abstract class Http2BaseFilter extends HttpBaseFilter {
      */
     protected Http2Session createHttp2Session(final Connection connection,
                                               final boolean isServer) {
-        
+
         final Http2Session http2Session =
             new Http2Session(connection, isServer, this);
 
@@ -826,18 +824,18 @@ public abstract class Http2BaseFilter extends HttpBaseFilter {
         if (maxConcurrentStreams != -1) {
             http2Session.setLocalMaxConcurrentStreams(maxConcurrentStreams);
         }
-        
+
         Http2Session.bind(connection, http2Session);
-        
+
         return http2Session;
     }
-    
+
     protected void onPrefaceReceived(final Http2Session http2Session) {
     }
-    
+
     void sendUpstream(final Http2Session http2Session,
             final Http2Stream stream, final HttpContent content) {
-        
+
         final HttpRequestPacket request = stream.getRequest();
         final HttpContext httpContext = HttpContext.newInstance(stream,
                 stream, stream, request);
@@ -862,7 +860,7 @@ public abstract class Http2BaseFilter extends HttpBaseFilter {
             });
         }
     }
-    
+
     void prepareIncomingRequest(final Http2Stream stream,
             final Http2Request request) {
 
@@ -887,12 +885,12 @@ public abstract class Http2BaseFilter extends HttpBaseFilter {
             // Send 505; Unsupported HTTP version
             HttpStatus.HTTP_VERSION_NOT_SUPPORTED_505.setValues(response);
             request.setProtocol(Protocol.HTTP_1_1);
-            
+
             return;
         }
 
         final MimeHeaders headers = request.getHeaders();
-        
+
         final DataChunk hostDC = headers.getValue(Header.Host);
 
         // Check host header
@@ -901,7 +899,7 @@ public abstract class Http2BaseFilter extends HttpBaseFilter {
         }
 
     }
-    
+
     void sendRstStream(final FilterChainContext ctx,
             final Http2Session http2Session,
             final int streamId, final ErrorCode errorCode) {
@@ -917,7 +915,7 @@ public abstract class Http2BaseFilter extends HttpBaseFilter {
     /**
      * Obtain {@link Http2Session} associated with the {@link Connection}
      * and prepare it for use.
-     * 
+     *
      * @param context {@link FilterChainContext}
      * @param isUpStream <tt>true</tt> if the {@link FilterChainContext} represents
      *          upstream {@link FilterChain} execution, or <tt>false</tt> otherwise
@@ -928,14 +926,14 @@ public abstract class Http2BaseFilter extends HttpBaseFilter {
     protected final Http2Session obtainHttp2Session(
             final FilterChainContext context,
             final boolean isUpStream) {
-        
+
         return obtainHttp2Session(null, context, isUpStream);
     }
 
     /**
      * Obtain {@link Http2Session} associated with the {@link Connection}
      * and prepare it for use.
-     * 
+     *
      * @param http2State {@link Http2State} associated with the {@link Connection}
      * @param context {@link FilterChainContext}
      * @param isUpStream <tt>true</tt> if the {@link FilterChainContext} represents
@@ -948,11 +946,11 @@ public abstract class Http2BaseFilter extends HttpBaseFilter {
             final FilterChainContext context,
             final boolean isUpStream) {
         final Connection connection = context.getConnection();
-        
+
         Http2Session http2Session = http2State != null
                 ? http2State.getHttp2Session()
                 : null;
-        
+
         if (http2Session == null) {
             http2Session = Http2Session.get(connection);
             if (http2Session == null) {
@@ -960,7 +958,7 @@ public abstract class Http2BaseFilter extends HttpBaseFilter {
                 http2Session = createHttp2Session(connection, true);
             }
         }
-        
+
         http2Session.setupFilterChains(context, isUpStream);
 
         return http2Session;
@@ -972,13 +970,13 @@ public abstract class Http2BaseFilter extends HttpBaseFilter {
         final SettingsFrame frame = SettingsFrame.builder()
                 .setAck()
                 .build();
-        
+
         context.write(
                 frameCodec.serializeAndRecycle(
                         http2Session, frame)
         );
     }
-    
+
     private static void processDataFrame(final Http2Session http2Session,
             final FilterChainContext context,
             final Http2Frame frame) throws IOException {

--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2FrameCodec.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2FrameCodec.java
@@ -27,7 +27,7 @@ import org.glassfish.grizzly.memory.MemoryManager;
 /**
  * The {@link Filter} responsible for transforming {@link Http2Frame}s
  * to {@link Buffer}s and vise versa.
- * 
+ *
  * @author Grizzly team
  */
 public class Http2FrameCodec {
@@ -44,16 +44,16 @@ public class Http2FrameCodec {
     public List<Http2Frame> parse(final Http2Session http2Session,
             final FrameParsingState parsingState, Buffer srcMessage)
             throws Http2SessionException {
-        
+
         if (parsingState.bytesToSkip() > 0) {
             if (!skip(parsingState, srcMessage)) {
                 return null;
             }
         }
-        
+
         srcMessage = parsingState.appendToRemainder(
                 http2Session.getMemoryManager(), srcMessage);
-        
+
         ParsingResult parsingResult = parseFrame(
                 http2Session, parsingState, srcMessage);
 
@@ -75,20 +75,6 @@ public class Http2FrameCodec {
         }
 
         return parsingResult.frameList();
-        
-//        // ------------ ERROR processing block -----------------------------
-//        final Buffer sndBuffer;
-//        final GoAwayFrame goAwayFrame =
-//                GoAwayFrame.builder()
-//                .errorCode(error.getErrorCode())
-//                .build();
-//        sndBuffer = goAwayFrame.toBuffer(http2State.getHttp2Session());
-//
-//        // send last message and close the connection
-//        ctx.write(sndBuffer);
-//        connection.closeSilently();
-//
-//        return ctx.getStopAction();
     }
 
     public Buffer serializeAndRecycle(final Http2Session http2Session,
@@ -117,39 +103,39 @@ public class Http2FrameCodec {
             resultBuffer = Buffers.appendBuffers(http2Session.getMemoryManager(),
                     resultBuffer, buffer);
         }
-        
+
         frames.clear();
-        
+
         return resultBuffer;
     }
-    
+
     // --------------------------------------------------------- Private Methods
 
     private ParsingResult parseFrame(final Http2Session http2Session,
             final FrameParsingState state,
             final Buffer buffer) throws Http2SessionException {
-        
+
         final int bufferSize = buffer.remaining();
         final ParsingResult parsingResult = state.parsingResult();
-        
-        
+
+
         if (bufferSize < Http2Frame.FRAME_HEADER_SIZE) {
             return parsingResult.setNeedMore(buffer);
         }
-        
+
         final int len = http2Session.getFrameSize(buffer);
-        
+
         if (len > http2Session.getPeerMaxFramePayloadSize() + Http2Frame.FRAME_HEADER_SIZE) {
-            
+
             http2Session.onOversizedFrame(buffer);
 
             // skip the frame header
             buffer.position(buffer.position() + Http2Frame.FRAME_HEADER_SIZE);
-            
+
             // figure out what to do with the remainder
             final Buffer remainder;
             final int remaining = buffer.remaining();
-            
+
             if (remaining > len) {
                 final int bufferPos = buffer.position();
                 remainder = buffer.split(bufferPos + len);
@@ -157,7 +143,7 @@ public class Http2FrameCodec {
                 remainder = Buffers.EMPTY_BUFFER;
                 state.bytesToSkip(len - remaining);
             }
-            
+
             return parsingResult.setParsed(null, remainder);
         }
 
@@ -170,31 +156,31 @@ public class Http2FrameCodec {
 
         return parsingResult.setParsed(frame, remainder);
     }
-    
+
     private boolean skip(final FrameParsingState parsingState,
             final Buffer message) {
-        
+
         final int bytesToSkip = parsingState.bytesToSkip();
-        
+
         final int dec = Math.min(bytesToSkip, message.remaining());
         parsingState.bytesToSkip(bytesToSkip - dec);
-        
+
         message.position(message.position() + dec);
-        
+
         if (message.hasRemaining()) {
             message.shrink();
             return true;
         }
-        
+
         message.tryDispose();
         return false;
     }
-    
+
     public final static class FrameParsingState {
         private int bytesToSkip;
         private final ParsingResult parsingResult =
                 new ParsingResult();
-        
+
         List<Http2Frame> getList() {
             return parsingResult.frameList;
         }
@@ -205,44 +191,44 @@ public class Http2FrameCodec {
             parsingResult.remainder = null;
             return Buffers.appendBuffers(mm, remainderBuffer, buffer, true);
         }
-        
+
         int bytesToSkip() {
             return bytesToSkip;
         }
-        
+
         void bytesToSkip(final int bytesToSkip) {
             this.bytesToSkip = bytesToSkip;
         }
-        
+
         ParsingResult parsingResult() {
             return parsingResult;
         }
     }
-    
+
     final static class ParsingResult {
         private Buffer remainder;
         private boolean isReady;
         private final List<Http2Frame> frameList = new ArrayList<>(4);
-        
+
         private ParsingResult() {
         }
-        
+
 
         ParsingResult setParsed(final Http2Frame frame, final Buffer remainder) {
             if (frame != null) {
                 frameList.add(frame);
             }
-            
+
             this.remainder = remainder;
             isReady = true;
-            
+
             return this;
         }
-        
+
         ParsingResult setNeedMore(final Buffer remainder) {
             this.remainder = remainder;
             isReady = false;
-            
+
             return this;
         }
 
@@ -253,9 +239,9 @@ public class Http2FrameCodec {
         Buffer remainder() {
             return remainder;
         }
-        
+
         boolean isReady() {
             return isReady;
         }
-    }    
+    }
 }

--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2Session.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2Session.java
@@ -292,7 +292,9 @@ public class Http2Session {
             throws Http2SessionException {
         // we assume the passed buffer represents only this frame, no remainders allowed
         final int len = getFrameSize(buffer);
-        assert buffer.remaining() == len;
+        if (buffer.remaining() != len) {
+            throw new Http2SessionException(ErrorCode.FRAME_SIZE_ERROR);
+        }
 
         final int i1 = buffer.getInt();
 

--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2Session.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2Session.java
@@ -670,6 +670,7 @@ public class Http2Session {
 
     // Must be locked by sessionLock
     private void pruneStreams() {
+        LOGGER.log(Level.FINE, "pruneStreams()");
         // close streams that rank above the last stream ID specified by the GOAWAY frame.
         // Allow other streams to continue processing.  Once the concurrent stream count reaches zero,
         // the session will be closed.
@@ -1190,6 +1191,7 @@ public class Http2Session {
      * Called from {@link Http2Stream} once stream is completely closed.
      */
     void deregisterStream() {
+        LOGGER.fine("deregisterStream()");
         final boolean isCloseSession;
         synchronized (sessionLock) {
             decStreamCount();

--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2Session.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2Session.java
@@ -611,9 +611,7 @@ public class Http2Session {
 
                 @Override
                 public void failed(final Throwable throwable) {
-                    if (LOGGER.isLoggable(Level.FINE)) {
-                        LOGGER.log(Level.FINE, "Unable to write GOAWAY.  Terminating session.", throwable);
-                    }
+                    LOGGER.log(Level.WARNING, "Unable to write GOAWAY.  Terminating session.", throwable);
                     close();
                 }
 
@@ -624,9 +622,7 @@ public class Http2Session {
 
                 @Override
                 public void cancelled() {
-                    if (LOGGER.isLoggable(Level.FINE)) {
-                        LOGGER.log(Level.FINE, "GOAWAY write cancelled.  Terminating session.");
-                    }
+                    LOGGER.log(Level.FINE, "GOAWAY write cancelled.  Terminating session.");
                     close();
                 }
             }, null);

--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2SessionOutputSink.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2SessionOutputSink.java
@@ -209,6 +209,7 @@ public class Http2SessionOutputSink {
             int writeCompletionHandlerBytes = 0;
             int bytesToTransfer = 0;
             int queueSizeToFree = 0;
+            boolean breakNow = false;
 
             // gather all available output data frames
             while (availWindowSize > bytesToTransfer && queueSize > queueSizeToFree) {
@@ -219,10 +220,9 @@ public class Http2SessionOutputSink {
                     LOGGER.log(Level.WARNING, "UNEXPECTED NULL RECORD. Queue-size: {0} "
                                     + "byteToTransfer={1} queueSizeToFree={2} queueSize={3}",
                             new Object[]{outputQueue.size(), bytesToTransfer, queueSizeToFree, queueSize});
+                    breakNow = true;
+                    break;
                 }
-
-                assert record != null;
-
                 final int serializedBytes = record.serializeTo(tmpFramesList,
                     Math.min(MAX_FRAME_PAYLOAD_SIZE, availWindowSize - bytesToTransfer));
                 bytesToTransfer += serializedBytes;
@@ -275,6 +275,9 @@ public class Http2SessionOutputSink {
 
             // release the writer lock, so other thread can start to write
             writerLock.set(false);
+            if (breakNow) {
+                break;
+            }
 
             // we don't want this thread to write all the time - so give more
             // time for another thread to start writing

--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2SessionOutputSink.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2SessionOutputSink.java
@@ -44,7 +44,6 @@ import org.glassfish.grizzly.http2.frames.Http2Frame;
 public class Http2SessionOutputSink {
     protected final Http2Session http2Session;
     private static final Logger LOGGER = Grizzly.logger(Http2SessionOutputSink.class);
-    private static final Level LOGGER_LEVEL = Level.FINE;
 
     private static final int MAX_FRAME_PAYLOAD_SIZE = 16383;
     private static final int MAX_OUTPUT_QUEUE_SIZE = 65536;
@@ -128,10 +127,9 @@ public class Http2SessionOutputSink {
             throw new Http2SessionException(ErrorCode.FLOW_CONTROL_ERROR, "Session flow-control window overflow.");
         }
         final int newWindowSize = availConnectionWindowSize.addAndGet(delta);
-        if (LOGGER.isLoggable(LOGGER_LEVEL)) {
-            LOGGER.log(LOGGER_LEVEL, "Http2Session. Expand connection window size by {0} bytes. Current connection window size is: {1}",
-                    new Object[] {delta, newWindowSize});
-        }
+        LOGGER.log(Level.FINE,
+            "Http2Session. Expand connection window size by {0} bytes. Current connection window size is: {1}",
+            new Object[] {delta, newWindowSize});
 
         flushOutputQueue();
     }
@@ -179,10 +177,7 @@ public class Http2SessionOutputSink {
             data = messageCloner.clone(http2Session.getConnection(), data);
         }
 
-        final Http2OutputQueueRecord record = new Http2OutputQueueRecord(
-                stream.getId(), data,
-                completionHandler, isLast);
-
+        final Http2OutputQueueRecord record = new Http2OutputQueueRecord(stream.getId(), data, completionHandler, isLast);
         outputQueue.offer(record);
         outputQueue.reserveSpace(record.isZeroSizeData() ? 1 : dataSize);
 
@@ -195,10 +190,7 @@ public class Http2SessionOutputSink {
         int availWindowSize;
         int queueSize;
 
-        boolean needToNotify = false;
-
-        // for debug purposes only
-        int tmpcnt = 0;
+        boolean needToNotifyQueueManagement = false;
 
         // try to flush entire output queue
 
@@ -212,33 +204,27 @@ public class Http2SessionOutputSink {
             availWindowSize = availConnectionWindowSize.get();
             queueSize = outputQueue.size();
 
+            AggrCompletionHandler completionHandlers = null;
             CompletionHandler<WriteResult> writeCompletionHandler = null;
             int writeCompletionHandlerBytes = 0;
-
             int bytesToTransfer = 0;
             int queueSizeToFree = 0;
 
-            AggrCompletionHandler completionHandlers = null;
-
             // gather all available output data frames
-            while (availWindowSize > bytesToTransfer &&
-                    queueSize > queueSizeToFree) {
+            while (availWindowSize > bytesToTransfer && queueSize > queueSizeToFree) {
 
                 final Http2OutputQueueRecord record = outputQueue.poll();
-
                 if (record == null) {
-                    // keep this warning for now
-                    // should be reported when null record is spotted
+                    // keep this warning for now - should be reported when null record is spotted
                     LOGGER.log(Level.WARNING, "UNEXPECTED NULL RECORD. Queue-size: {0} "
-                                    + "tmpcnt={1} byteToTransfer={2} queueSizeToFree={3} queueSize={4}",
-                            new Object[]{outputQueue.size(), tmpcnt, bytesToTransfer, queueSizeToFree, queueSize});
+                                    + "byteToTransfer={1} queueSizeToFree={2} queueSize={3}",
+                            new Object[]{outputQueue.size(), bytesToTransfer, queueSizeToFree, queueSize});
                 }
 
                 assert record != null;
 
-                final int serializedBytes = record.serializeTo(
-                        tmpFramesList,
-                        Math.min(MAX_FRAME_PAYLOAD_SIZE, availWindowSize - bytesToTransfer));
+                final int serializedBytes = record.serializeTo(tmpFramesList,
+                    Math.min(MAX_FRAME_PAYLOAD_SIZE, availWindowSize - bytesToTransfer));
                 bytesToTransfer += serializedBytes;
                 queueSizeToFree += serializedBytes;
 
@@ -250,25 +236,21 @@ public class Http2SessionOutputSink {
                     outputQueue.setCurrentElement(record);
                 }
 
-                final CompletionHandler<WriteResult> recordCompletionHandler =
-                        record.getCompletionHandler();
+                final CompletionHandler<WriteResult> recordCompletionHandler = record.getCompletionHandler();
 
                 // add this record CompletionHandler to the list of
                 // CompletionHandlers to be notified once all the frames are
                 // written
                 if (recordCompletionHandler != null) {
                     if (completionHandlers != null) {
-                        completionHandlers.register(recordCompletionHandler,
-                                serializedBytes);
+                        completionHandlers.register(recordCompletionHandler, serializedBytes);
                     } else if (writeCompletionHandler == null) {
                         writeCompletionHandler = recordCompletionHandler;
                         writeCompletionHandlerBytes = serializedBytes;
                     } else {
                         completionHandlers = new AggrCompletionHandler();
-                        completionHandlers.register(writeCompletionHandler,
-                                writeCompletionHandlerBytes);
-                        completionHandlers.register(recordCompletionHandler,
-                                serializedBytes);
+                        completionHandlers.register(writeCompletionHandler, writeCompletionHandlerBytes);
+                        completionHandlers.register(recordCompletionHandler, serializedBytes);
                         writeCompletionHandler = completionHandlers;
                     }
                 }
@@ -281,17 +263,14 @@ public class Http2SessionOutputSink {
                 // write the frame list
                 writeDownStream(tmpFramesList, writeCompletionHandler, null);
 
-                final int newWindowSize =
-                        availConnectionWindowSize.addAndGet(-bytesToTransfer);
+                final int newWindowSize = availConnectionWindowSize.addAndGet(-bytesToTransfer);
 
                 outputQueue.releaseSpace(queueSizeToFree);
 
-                needToNotify = true;
-                if (LOGGER.isLoggable(LOGGER_LEVEL)) {
-                    LOGGER.log(LOGGER_LEVEL, "Http2Session. Shrink connection window size by {0} bytes. Current connection window size is: {1}",
-                            new Object[] {bytesToTransfer, newWindowSize});
-                }
-
+                needToNotifyQueueManagement = true;
+                LOGGER.log(Level.FINE,
+                    "Http2Session. Shrink connection window size by {0} bytes. Current connection window size is: {1}",
+                    new Object[] {bytesToTransfer, newWindowSize});
             }
 
             // release the writer lock, so other thread can start to write
@@ -300,10 +279,9 @@ public class Http2SessionOutputSink {
             // we don't want this thread to write all the time - so give more
             // time for another thread to start writing
             LockSupport.parkNanos(backoffDelay++);
-            tmpcnt++;
         }
 
-        if (needToNotify) {
+        if (needToNotifyQueueManagement) {
             outputQueue.doNotify();
         }
     }

--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2Stream.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2Stream.java
@@ -624,8 +624,8 @@ public class Http2Stream implements AttributeStorage, OutputSink, Closeable {
             http2Session.streamsToFlushInput.add(this);
         }
     }
-    
-    void flushInputData() {
+
+    void flushInputData() throws Http2SessionException {
         final Buffer cachedInputBufferLocal = cachedInputBuffer;
         final boolean cachedIsLastLocal = cachedIsLast;
         cachedInputBuffer = null;
@@ -646,11 +646,15 @@ public class Http2Stream implements AttributeStorage, OutputSink, Closeable {
             }
 
             final int size = cachedInputBufferLocal.remaining();
-            if (!inputBuffer.offer(cachedInputBufferLocal, cachedIsLastLocal)) {
-                // if we can't add this buffer to the stream input buffer -
-                // we have to release the part of connection window allocated
-                // for the buffer
-                http2Session.ackConsumedData(size);
+            try {
+                if (!inputBuffer.offer(cachedInputBufferLocal, cachedIsLastLocal)) {
+                    // if we can't add this buffer to the stream input buffer -
+                    // we have to release the part of connection window allocated
+                    // for the buffer
+                    http2Session.ackConsumedData(size);
+                }
+            } catch (final RuntimeException e) {
+                throw new Http2SessionException(ErrorCode.PROTOCOL_ERROR, e.getMessage());
             }
         }
     }

--- a/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2Stream.java
+++ b/modules/http2/src/main/java/org/glassfish/grizzly/http2/Http2Stream.java
@@ -60,7 +60,7 @@ import static org.glassfish.grizzly.http2.Termination.UNEXPECTED_FRAME_TERMINATI
 
 /**
  * The abstraction representing HTTP2 stream.
- * 
+ *
  * @author Grizzly team
  */
 public class Http2Stream implements AttributeStorage, OutputSink, Closeable {
@@ -83,12 +83,12 @@ public class Http2Stream implements AttributeStorage, OutputSink, Closeable {
             HttpRequestPacket.READ_ONLY_ATTR_PREFIX + "parent." + Http2Stream.class.getName();
 
     static final int UPGRADE_STREAM_ID = 1;
-    
+
     private static final Attribute<Http2Stream> HTTP_RQST_HTTP2_STREAM_ATTR =
             AttributeBuilder.DEFAULT_ATTRIBUTE_BUILDER.createAttribute("http2.request.stream");
 
     State state = State.IDLE;
-    
+
     private final HttpRequestPacket request;
     private final int streamId;
     private final int parentStreamId;
@@ -96,19 +96,19 @@ public class Http2Stream implements AttributeStorage, OutputSink, Closeable {
     private final boolean exclusive;
 
     private final Http2Session http2Session;
-    
+
     private final AttributeHolder attributes =
             AttributeBuilder.DEFAULT_ATTRIBUTE_BUILDER.createSafeAttributeHolder();
 
     final StreamInputBuffer inputBuffer;
     final StreamOutputSink outputSink;
-    
+
     // number of bytes reported to be read, but still unacked to the peer
     static final AtomicIntegerFieldUpdater<Http2Stream> unackedReadBytesUpdater =
             AtomicIntegerFieldUpdater.newUpdater(Http2Stream.class, "unackedReadBytes");
     @SuppressWarnings("unused")
     private volatile int unackedReadBytes;
-    
+
     // closeReasonRef, "null" value means the connection is open.
     private static final AtomicReferenceFieldUpdater<Http2Stream, CloseReason> closeReasonUpdater =
             AtomicReferenceFieldUpdater.newUpdater(Http2Stream.class, CloseReason.class, "closeReason");
@@ -116,10 +116,10 @@ public class Http2Stream implements AttributeStorage, OutputSink, Closeable {
     private volatile CloseReason closeReason;
 
     private volatile GrizzlyFuture<CloseReason> closeFuture;
-    
+
     private final Queue<CloseListener> closeListeners =
             new ConcurrentLinkedQueue<>();
-    
+
     private static final AtomicIntegerFieldUpdater<Http2Stream> completeFinalizationCounterUpdater =
             AtomicIntegerFieldUpdater.newUpdater(Http2Stream.class, "completeFinalizationCounter");
     @SuppressWarnings("unused")
@@ -127,10 +127,10 @@ public class Http2Stream implements AttributeStorage, OutputSink, Closeable {
 
     // flag, which is indicating if Http2Stream processing has been marked as complete by external code
     volatile boolean isProcessingComplete;
-    
+
     // the counter for inbound HeaderFrames
     private int inboundHeaderFramesCounter;
-    
+
     public static Http2Stream getStreamFor(final HttpHeader httpHeader) {
         final HttpRequestPacket request;
 
@@ -142,18 +142,18 @@ public class Http2Stream implements AttributeStorage, OutputSink, Closeable {
             assert httpHeader instanceof HttpResponsePacket;
             request = ((HttpResponsePacket) httpHeader).getRequest();
         }
-        
-        
+
+
         if (request != null) {
             return HTTP_RQST_HTTP2_STREAM_ATTR.get(request);
         }
-        
+
         return null;
     }
 
     /**
      * Create HTTP2 stream.
-     * 
+     *
      * @param http2Session the {@link Http2Session} for this {@link Http2Stream}.
      * @param request the {@link HttpRequestPacket} initiating the stream.
      * @param streamId this stream's ID.
@@ -174,7 +174,7 @@ public class Http2Stream implements AttributeStorage, OutputSink, Closeable {
 
         inputBuffer = new DefaultInputBuffer(this);
         outputSink = new DefaultOutputSink(this);
-        
+
         HTTP_RQST_HTTP2_STREAM_ATTR.set(request, this);
     }
 
@@ -198,14 +198,14 @@ public class Http2Stream implements AttributeStorage, OutputSink, Closeable {
         inputBuffer = http2Session.isServer()
                 ? new UpgradeInputBuffer(this)
                 : new DefaultInputBuffer(this);
-        
+
         outputSink = http2Session.isServer()
                 ? new DefaultOutputSink(this)
                 : new UpgradeOutputSink(http2Session);
-        
+
         HTTP_RQST_HTTP2_STREAM_ATTR.set(request, this);
     }
-    
+
     Http2Session getHttp2Session() {
         return http2Session;
     }
@@ -217,18 +217,18 @@ public class Http2Stream implements AttributeStorage, OutputSink, Closeable {
     public int getLocalWindowSize() {
         return http2Session.getLocalStreamWindowSize();
     }
-    
+
     /**
      * @return the number of writes (not bytes), that haven't reached network layer
      */
     public int getUnflushedWritesCount() {
         return outputSink.getUnflushedWritesCount() ;
     }
-    
+
     public HttpRequestPacket getRequest() {
         return request;
     }
-    
+
     public HttpResponsePacket getResponse() {
         return request.getResponse();
     }
@@ -237,7 +237,7 @@ public class Http2Stream implements AttributeStorage, OutputSink, Closeable {
     public boolean isPushEnabled() {
         return http2Session.isPushEnabled();
     }
-    
+
     public int getId() {
         return streamId;
     }
@@ -255,7 +255,7 @@ public class Http2Stream implements AttributeStorage, OutputSink, Closeable {
     public boolean isPushStream() {
         return (streamId & 1) == 0;
     }
-    
+
     public boolean isLocallyInitiatedStream() {
         return http2Session.isLocallyInitiatedStream(streamId);
     }
@@ -270,11 +270,11 @@ public class Http2Stream implements AttributeStorage, OutputSink, Closeable {
         if (!isOpen()) {
             final CloseReason cr = this.closeReason;
             assert cr != null;
-            
+
             throw new IOException("closed", cr.getCause());
         }
     }
-    
+
     @Override
     public AttributeHolder getAttributes() {
         return attributes;
@@ -285,7 +285,7 @@ public class Http2Stream implements AttributeStorage, OutputSink, Closeable {
     public boolean canWrite(int length) {
         return canWrite();
     }
-    
+
     @Override
     public boolean canWrite() {
         return outputSink.canWrite();
@@ -296,7 +296,7 @@ public class Http2Stream implements AttributeStorage, OutputSink, Closeable {
     public void notifyCanWrite(final WriteHandler handler, final int length) {
         notifyCanWrite(handler);
     }
-    
+
     @Override
     public void notifyCanWrite(final WriteHandler writeHandler) {
         outputSink.notifyWritePossible(writeHandler);
@@ -305,12 +305,12 @@ public class Http2Stream implements AttributeStorage, OutputSink, Closeable {
     StreamOutputSink getOutputSink() {
         return outputSink;
     }
-    
+
     @Override
     public GrizzlyFuture<Closeable> terminate() {
         final FutureImpl<Closeable> future = Futures.createSafeFuture();
         close0(Futures.toCompletionHandler(future), CloseType.LOCALLY, null, false);
-        
+
         return future;
     }
 
@@ -328,7 +328,7 @@ public class Http2Stream implements AttributeStorage, OutputSink, Closeable {
     public GrizzlyFuture<Closeable> close() {
         final FutureImpl<Closeable> future = Futures.createSafeFuture();
         close0(Futures.toCompletionHandler(future), CloseType.LOCALLY, null, true);
-        
+
         return future;
     }
 
@@ -341,6 +341,7 @@ public class Http2Stream implements AttributeStorage, OutputSink, Closeable {
      * {@inheritDoc}
      * @deprecated please use {@link #close()} with the following {@link GrizzlyFuture#addCompletionHandler(org.glassfish.grizzly.CompletionHandler)} call
      */
+    @Deprecated
     @Override
     public void close(final CompletionHandler<Closeable> completionHandler) {
         close0(completionHandler, CloseType.LOCALLY, null, true);
@@ -359,21 +360,21 @@ public class Http2Stream implements AttributeStorage, OutputSink, Closeable {
 
         if (closeReasonUpdater.compareAndSet(this, null,
                 new CloseReason(closeType, cause))) {
-            
+
             final Termination termination = closeType == CloseType.LOCALLY ?
-                    LOCAL_CLOSE_TERMINATION : 
+                    LOCAL_CLOSE_TERMINATION :
                     PEER_CLOSE_TERMINATION;
-            
+
             // Terminate the input, discard already buffered data
             inputBuffer.terminate(termination);
-            
+
             if (isCloseOutputGracefully) {
                 outputSink.close();
             } else {
                 // Terminate the output, discard all the pending data in the output buffer
                 outputSink.terminate(termination);
             }
-            
+
             notifyCloseListeners();
 
             if (completionHandler != null) {
@@ -397,7 +398,7 @@ public class Http2Stream implements AttributeStorage, OutputSink, Closeable {
             }
         });
     }
-    
+
     /**
      * Notify the Http2Stream that peer sent RST_FRAME.
      */
@@ -408,14 +409,14 @@ public class Http2Stream implements AttributeStorage, OutputSink, Closeable {
             // initial graceful shutdown for input, so user is able to read
             // the buffered data
             inputBuffer.terminate(RESET_TERMINATION);
-            
+
             // forcibly terminate the output, so no more data will be sent
             outputSink.terminate(RESET_TERMINATION);
         }
-        
+
 //        rstAssociatedStreams();
     }
-    
+
     void onProcessingComplete() {
         isProcessingComplete = true;
         close();
@@ -428,12 +429,12 @@ public class Http2Stream implements AttributeStorage, OutputSink, Closeable {
 //            notifyCloseListeners();
 //        }
     }
-    
+
     @Override
     @SuppressWarnings("unchecked")
     public void addCloseListener(final CloseListener closeListener) {
         CloseReason cr = closeReason;
-        
+
         // check if connection is still open
         if (cr == null) {
             // add close listener
@@ -489,10 +490,10 @@ public class Http2Stream implements AttributeStorage, OutputSink, Closeable {
                 }
             }
         }
-        
+
         return closeFuture;
     }
-    
+
     void onInputClosed() {
         if (completeFinalizationCounterUpdater.incrementAndGet(this) == 2) {
             closeStream();
@@ -512,7 +513,7 @@ public class Http2Stream implements AttributeStorage, OutputSink, Closeable {
     /**
      * The method is called when an inbound headers are decoded for the stream,
      * which means all the header frames arrived and we're ready to parse the headers.
-     * 
+     *
      * @param isEOS flag indicating if the end-of-stream has been reached
      *
      * @throws Http2StreamException if an error occurs processing the headers frame
@@ -520,10 +521,10 @@ public class Http2Stream implements AttributeStorage, OutputSink, Closeable {
     void onRcvHeaders(final boolean isEOS) throws Http2StreamException {
 
         inboundHeaderFramesCounter++;
-        
+
         switch (inboundHeaderFramesCounter) {
             case 1: // first header block to process
-                
+
                 // change the state
                 onReceiveHeaders();
                 if (isEOS) {
@@ -535,7 +536,7 @@ public class Http2Stream implements AttributeStorage, OutputSink, Closeable {
                 if (isEOS) {
                     break;  // trailing headers
                 }
-                
+
                 // otherwise goto "default" and throw an error
             }
             default: { // WHAT?
@@ -545,7 +546,7 @@ public class Http2Stream implements AttributeStorage, OutputSink, Closeable {
             }
         }
     }
-    
+
     /**
      * The method is called when an outbound headers are about to be sent to the peer.
      *
@@ -561,7 +562,7 @@ public class Http2Stream implements AttributeStorage, OutputSink, Closeable {
 
     private Buffer cachedInputBuffer;
     private boolean cachedIsLast;
-    
+
     private IOException assertCanAcceptData(final boolean fin) {
         if (isPushStream() && isLocallyInitiatedStream()) {
             return new Http2StreamException(getId(),
@@ -584,11 +585,11 @@ public class Http2Stream implements AttributeStorage, OutputSink, Closeable {
         if (inboundHeaderFramesCounter != 1) { // we accept data only if we received one HeadersFrame
             close0(null, CloseType.LOCALLY,
                     new IOException("DATA frame came before HEADERS frame."), false);
-            
+
             return new Http2StreamException(getId(),
                     ErrorCode.PROTOCOL_ERROR, "DATA frame came before HEADERS frame.");
         }
-        
+
         return null;
     }
 
@@ -607,7 +608,7 @@ public class Http2Stream implements AttributeStorage, OutputSink, Closeable {
 
         return null;
     }
-    
+
     void offerInputData(final Buffer data, final boolean fin) throws IOException {
         IOException ex = assertCanAcceptData(fin);
         if (ex != null) {
@@ -618,7 +619,7 @@ public class Http2Stream implements AttributeStorage, OutputSink, Closeable {
         cachedInputBuffer = Buffers.appendBuffers(
                 http2Session.getMemoryManager(),
                 cachedInputBuffer, data);
-        
+
         if (isFirstBufferCached) {
             http2Session.streamsToFlushInput.add(this);
         }
@@ -643,7 +644,7 @@ public class Http2Stream implements AttributeStorage, OutputSink, Closeable {
                 cachedInputBufferLocal.allowBufferDispose(true);
                 ((CompositeBuffer) cachedInputBufferLocal).disposeOrder(DisposeOrder.LAST_TO_FIRST);
             }
-            
+
             final int size = cachedInputBufferLocal.remaining();
             if (!inputBuffer.offer(cachedInputBufferLocal, cachedIsLastLocal)) {
                 // if we can't add this buffer to the stream input buffer -
@@ -653,36 +654,36 @@ public class Http2Stream implements AttributeStorage, OutputSink, Closeable {
             }
         }
     }
-    
+
     HttpContent pollInputData() throws IOException {
         return inputBuffer.poll();
     }
-    
+
     private void closeStream() {
         // TODO ensure stream proper transitions to CLOSED state
         //Http2StreamState.close(this);
         http2Session.deregisterStream();
     }
-    
+
     HttpHeader getInputHttpHeader() {
         return (isLocallyInitiatedStream() ^ isPushStream()) ?
                 request.getResponse() :
                 request;
     }
-    
+
     HttpHeader getOutputHttpHeader() {
         return (!isLocallyInitiatedStream() ^ isPushStream()) ?
                 request.getResponse() :
                 request;
     }
-    
+
     /**
      * Notify all close listeners
      */
     @SuppressWarnings("unchecked")
     private void notifyCloseListeners() {
         final CloseReason cr = closeReason;
-        
+
         CloseListener closeListener;
         while ((closeListener = closeListeners.poll()) != null) {
             try {

--- a/modules/http2/src/test/java/org/glassfish/grizzly/http2/TrailersTest.java
+++ b/modules/http2/src/test/java/org/glassfish/grizzly/http2/TrailersTest.java
@@ -36,6 +36,7 @@ import org.glassfish.grizzly.http.util.MimeHeaders;
 import org.glassfish.grizzly.memory.Buffers;
 import org.glassfish.grizzly.memory.MemoryManager;
 import org.glassfish.grizzly.nio.transport.TCPNIOConnectorHandler;
+import org.glassfish.grizzly.nio.transport.TCPNIOTransport;
 import org.junit.After;
 import org.junit.Test;
 
@@ -76,10 +77,10 @@ public class TrailersTest extends AbstractHttp2Test {
         configureHttpServer();
         startHttpServer(new HttpHandler() {
             @Override
-            public void service(Request request, Response response) throws Exception {
+            public void service(final Request request, final Response response) throws Exception {
                 response.setContentType("text/plain");
                 final InputStream in = request.getInputStream();
-                StringBuilder sb = new StringBuilder();
+                final StringBuilder sb = new StringBuilder();
                 int b;
                 while ((b = in.read()) != -1) {
                     sb.append((char) b);
@@ -104,7 +105,7 @@ public class TrailersTest extends AbstractHttp2Test {
 
         final Filter filter = new BaseFilter() {
             @Override
-            public NextAction handleRead(FilterChainContext ctx) throws IOException {
+            public NextAction handleRead(final FilterChainContext ctx) throws IOException {
                 final HttpContent httpContent = ctx.getMessage();
                 try {
                     if (lastProcessed.get()) {
@@ -121,7 +122,7 @@ public class TrailersTest extends AbstractHttp2Test {
                         latch.countDown();
                     } else {
                         assertFalse(httpContent instanceof HttpTrailer);
-                        int result = contentCount.incrementAndGet();
+                        final int result = contentCount.incrementAndGet();
                         if (result == 1) {
                             assertTrue(httpContent.getContent().remaining() == 0); // response
                         } else if (result == 2) {
@@ -130,7 +131,7 @@ public class TrailersTest extends AbstractHttp2Test {
                             fail("Unexpected content");
                         }
                     }
-                } catch (Throwable t) {
+                } catch (final Throwable t) {
                     error.set(t);
                     latch.countDown();
                 }
@@ -139,17 +140,11 @@ public class TrailersTest extends AbstractHttp2Test {
             }
         };
         final Connection<?> c = getConnection("localhost", PORT, filter);
-        HttpRequestPacket.Builder builder = HttpRequestPacket.builder();
-        HttpRequestPacket request = builder.method(Method.POST)
-                .uri("/echo")
-                .protocol(Protocol.HTTP_2_0)
-                .host("localhost:" + PORT).build();
-        c.write(HttpTrailer.builder(request)
-                .content(Buffers.wrap(MemoryManager.DEFAULT_MEMORY_MANAGER, "a=b&c=d"))
-                .last(true)
-                .header("trailer-a", "value-a")
-                .header("trailer-b", "value-b")
-                .build());
+        final HttpRequestPacket.Builder builder = HttpRequestPacket.builder();
+        final HttpRequestPacket request = builder.method(Method.POST).uri("/echo")
+            .protocol(Protocol.HTTP_2_0).host("localhost:" + PORT).build();
+        c.write(HttpTrailer.builder(request).content(Buffers.wrap(MemoryManager.DEFAULT_MEMORY_MANAGER, "a=b&c=d"))
+            .last(true).header("trailer-a", "value-a").header("trailer-b", "value-b").build());
         assertTrue(latch.await(10, TimeUnit.SECONDS));
         final Throwable t = error.get();
         if (t != null) {
@@ -164,7 +159,7 @@ public class TrailersTest extends AbstractHttp2Test {
         configureHttpServer();
         startHttpServer(new HttpHandler() {
             @Override
-            public void service(Request request, Response response) throws Exception {
+            public void service(final Request request, final Response response) throws Exception {
                 response.setContentType("text/plain");
                 final InputStream in = request.getInputStream();
                 //noinspection StatementWithEmptyBody
@@ -184,20 +179,19 @@ public class TrailersTest extends AbstractHttp2Test {
 
         final Filter filter = new BaseFilter() {
             @Override
-            public NextAction handleRead(FilterChainContext ctx) throws IOException {
+            public NextAction handleRead(final FilterChainContext ctx) throws IOException {
                 final HttpContent httpContent = ctx.getMessage();
                 try {
                     if (httpContent.isLast()) {
                         assertTrue(httpContent instanceof HttpTrailer);
                         final MimeHeaders trailers = ((HttpTrailer) httpContent).getHeaders();
-
                         assertEquals(2, trailers.size());
                         assertEquals("value-a", trailers.getHeader("trailer-a"));
                         assertEquals("value-b", trailers.getHeader("trailer-b"));
-                        latch.countDown();
                     }
-                } catch (Throwable t) {
+                } catch (final Throwable t) {
                     error.set(t);
+                } finally {
                     latch.countDown();
                 }
 
@@ -205,20 +199,14 @@ public class TrailersTest extends AbstractHttp2Test {
             }
         };
         final Connection<?> c = getConnection("localhost", PORT, filter);
-        HttpRequestPacket.Builder builder = HttpRequestPacket.builder();
-        HttpRequestPacket request = builder.method(Method.POST)
-                .uri("/echo")
-                .protocol(Protocol.HTTP_2_0)
-                .host("localhost:" + PORT).build();
-        c.write(HttpContent.builder(request) // write the request
-                .last(false)
-                .build());
-        c.write(HttpTrailer.builder(request) // write the trailer
-                .content(Buffers.EMPTY_BUFFER)
-                .last(true)
-                .header("trailer-a", "value-a")
-                .header("trailer-b", "value-b")
-                .build());
+        final HttpRequestPacket.Builder builder = HttpRequestPacket.builder();
+        final HttpRequestPacket request = builder.method(Method.POST).uri("/echo")
+            .protocol(Protocol.HTTP_2_0).host("localhost:" + PORT).build();
+        // write the request
+        c.write(HttpContent.builder(request).last(false).build());
+        // write the trailer
+        c.write(HttpTrailer.builder(request).content(Buffers.EMPTY_BUFFER).last(true)
+            .header("trailer-a", "value-a").header("trailer-b", "value-b").build());
         assertTrue(latch.await(10, TimeUnit.SECONDS));
         final Throwable t = error.get();
         if (t != null) {
@@ -249,12 +237,9 @@ public class TrailersTest extends AbstractHttp2Test {
         final FilterChain clientChain =
                 createClientFilterChainAsBuilder(false, true, clientFilter).build();
 
-        SocketConnectorHandler connectorHandler = TCPNIOConnectorHandler.builder(
-                httpServer.getListener("grizzly").getTransport())
-                .processor(clientChain)
-                .build();
-
-        Future<Connection> connectFuture = connectorHandler.connect(host, port);
+        final TCPNIOTransport transport = httpServer.getListener("grizzly").getTransport();
+        final SocketConnectorHandler connectorHandler = TCPNIOConnectorHandler.builder(transport).processor(clientChain).build();
+        final Future<Connection> connectFuture = connectorHandler.connect(host, port);
         return connectFuture.get(10, TimeUnit.SECONDS);
 
     }

--- a/modules/monitoring/grizzly/pom.xml
+++ b/modules/monitoring/grizzly/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-framework-monitoring</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>grizzly-framework-monitoring</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/monitoring/http-server/pom.xml
+++ b/modules/monitoring/http-server/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-server-monitoring</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>grizzly-http-server-monitoring</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/monitoring/http/pom.xml
+++ b/modules/monitoring/http/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-monitoring</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>grizzly-http-monitoring</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/monitoring/pom.xml
+++ b/modules/monitoring/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-monitoring</artifactId>
     <packaging>pom</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>grizzly-monitoring</name>
     <modules>
         <module>grizzly</module>

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-modules</artifactId>
     <packaging>pom</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>grizzly-modules</name>
     <profiles>
         <profile>

--- a/modules/portunif/pom.xml
+++ b/modules/portunif/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-portunif</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>grizzly-portunif</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/websockets/pom.xml
+++ b/modules/websockets/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-websockets</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>grizzly-websockets</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-bom</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>bom/pom.xml</relativePath>
     </parent>
 
@@ -28,7 +28,7 @@
     <artifactId>grizzly-project</artifactId>
     <packaging>pom</packaging>
     <name>grizzly-project</name>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <url>http://grizzly.java.net</url>
     <issueManagement>
         <system>GitHub</system>

--- a/samples/connection-pool-samples/pom.xml
+++ b/samples/connection-pool-samples/pom.xml
@@ -15,14 +15,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>connection-pool-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>connection-pool-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/framework-samples/pom.xml
+++ b/samples/framework-samples/pom.xml
@@ -15,14 +15,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
      <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-framework-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>grizzly-framework-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/http-ajp-samples/pom.xml
+++ b/samples/http-ajp-samples/pom.xml
@@ -15,14 +15,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
      <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-http-ajp-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>grizzly-http-ajp-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/http-jaxws-samples/pom.xml
+++ b/samples/http-jaxws-samples/pom.xml
@@ -15,14 +15,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-http-jaxws-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>grizzly-http-jaxws-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/http-multipart-samples/pom.xml
+++ b/samples/http-multipart-samples/pom.xml
@@ -15,14 +15,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-http-multipart-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>grizzly-http-multipart-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/http-samples/pom.xml
+++ b/samples/http-samples/pom.xml
@@ -15,14 +15,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-http-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>grizzly-http-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/http-server-samples/pom.xml
+++ b/samples/http-server-samples/pom.xml
@@ -15,14 +15,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-http-server-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>grizzly-http-server-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -15,14 +15,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-samples</artifactId>
     <packaging>pom</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>grizzly-samples</name>
     <modules>
         <module>framework-samples</module>

--- a/samples/portunif/pom.xml
+++ b/samples/portunif/pom.xml
@@ -15,14 +15,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
      <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-portunif-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>grizzly-portunif-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/tls-sni-samples/pom.xml
+++ b/samples/tls-sni-samples/pom.xml
@@ -15,14 +15,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.4.4.payara-p4</version>
+        <version>2.4.4.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-tls-sni-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.4.4.payara-p4</version>
+    <version>2.4.4.payara-p5-SNAPSHOT</version>
     <name>grizzly-tls-sni-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>


### PR DESCRIPTION
This is a PR with commits going also into Eclipse's master (3.0.0-SNAPSHOT) backported also to Payara maintenance.

The release of 2.4.4.payara-p5 is not planned at this moment, but this branch was used to test changes with yesterday's state of Payara Server master and passed all available tests.

Current Payara 5.2020.7-SNAPSHOT with these commits in it's own patch of Grizzly passed following tests:

*  all Grizzly's own tests
*  all Payara's own tests
*  TCK - websockets
*  TCK - servlet
*  my private test using arquillian and Apache HTTP Client and customized reproducer from https://github.com/eclipse-ee4j/grizzly/issues/2016
* HTTP/2 Push reproducer "[100 Delphines](https://bitbucket.org/luminositylabs/payara-2625/src/master/)" (after reconfiguring Payara a bit to use 100 threads for HTTP or more)
        note - this test causes exceptions with Firefox (remote stream reset), but no exceptions on Chrome
* Reproducer from this issue https://github.com/eclipse-ee4j/grizzly/issues/2111 (PrimeFaces Showcase)