### PR TITLE
Fish 9690 filtering incorrect characters from header rfc 9110

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -55,7 +55,7 @@
     <artifactId>grizzly-bom</artifactId>
     <packaging>pom</packaging>
     <name>grizzly-bom</name>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
 
     <description>Grizzly Bill of Materials (BOM)</description>
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -55,7 +55,7 @@
     <artifactId>grizzly-bom</artifactId>
     <packaging>pom</packaging>
     <name>grizzly-bom</name>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
 
     <description>Grizzly Bill of Materials (BOM)</description>
 

--- a/extras/bundles/grizzly-httpservice-bundle/pom.xml
+++ b/extras/bundles/grizzly-httpservice-bundle/pom.xml
@@ -44,13 +44,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
     <name>Grizzly OSGi HttpService Bundle</name>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <groupId>org.glassfish.grizzly.osgi</groupId>
     <artifactId>grizzly-httpservice-bundle</artifactId>
     <build>

--- a/extras/bundles/grizzly-httpservice-bundle/pom.xml
+++ b/extras/bundles/grizzly-httpservice-bundle/pom.xml
@@ -44,13 +44,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
     <name>Grizzly OSGi HttpService Bundle</name>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <groupId>org.glassfish.grizzly.osgi</groupId>
     <artifactId>grizzly-httpservice-bundle</artifactId>
     <build>

--- a/extras/bundles/pom.xml
+++ b/extras/bundles/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-extra-bundles</artifactId>
     <packaging>pom</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-extra-bundles</name>
 
     <modules>

--- a/extras/bundles/pom.xml
+++ b/extras/bundles/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-extra-bundles</artifactId>
     <packaging>pom</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-extra-bundles</name>
 
     <modules>

--- a/extras/connection-pool/pom.xml
+++ b/extras/connection-pool/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>connection-pool</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>connection-pool</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/extras/connection-pool/pom.xml
+++ b/extras/connection-pool/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>connection-pool</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>connection-pool</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/extras/grizzly-httpservice/pom.xml
+++ b/extras/grizzly-httpservice/pom.xml
@@ -44,14 +44,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
     <name>Grizzly OSGi HttpService</name>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <groupId>org.glassfish.grizzly.osgi</groupId>
     <artifactId>grizzly-httpservice</artifactId>
     <dependencies>

--- a/extras/grizzly-httpservice/pom.xml
+++ b/extras/grizzly-httpservice/pom.xml
@@ -44,14 +44,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
     <name>Grizzly OSGi HttpService</name>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <groupId>org.glassfish.grizzly.osgi</groupId>
     <artifactId>grizzly-httpservice</artifactId>
     <dependencies>

--- a/extras/http-server-jaxws/pom.xml
+++ b/extras/http-server-jaxws/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-server-jaxws</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-http-server-jaxws</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/extras/http-server-jaxws/pom.xml
+++ b/extras/http-server-jaxws/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-server-jaxws</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-http-server-jaxws</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/extras/http-server-multipart/pom.xml
+++ b/extras/http-server-multipart/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-server-multipart</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-http-server-multipart</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/extras/http-server-multipart/pom.xml
+++ b/extras/http-server-multipart/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-server-multipart</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-http-server-multipart</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/extras/http-servlet-extras/pom.xml
+++ b/extras/http-servlet-extras/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-servlet-extras</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-http-servlet-extras</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/extras/http-servlet-extras/pom.xml
+++ b/extras/http-servlet-extras/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-servlet-extras</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-http-servlet-extras</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/extras/pom.xml
+++ b/extras/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-extras</artifactId>
     <packaging>pom</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-extras</name>
     <profiles>
         <profile>

--- a/extras/pom.xml
+++ b/extras/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-extras</artifactId>
     <packaging>pom</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-extras</name>
     <profiles>
         <profile>

--- a/extras/tls-sni/pom.xml
+++ b/extras/tls-sni/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>tls-sni</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>tls-sni</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/extras/tls-sni/pom.xml
+++ b/extras/tls-sni/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>tls-sni</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>tls-sni</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/bundles/comet/pom.xml
+++ b/modules/bundles/comet/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-comet-server</artifactId>
     <packaging>jar</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-comet-server</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/bundles/comet/pom.xml
+++ b/modules/bundles/comet/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-comet-server</artifactId>
     <packaging>jar</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-comet-server</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/bundles/core/pom.xml
+++ b/modules/bundles/core/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-core</artifactId>
     <packaging>jar</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-core</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/bundles/core/pom.xml
+++ b/modules/bundles/core/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-core</artifactId>
     <packaging>jar</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-core</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/bundles/http-all/pom.xml
+++ b/modules/bundles/http-all/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-all</artifactId>
     <packaging>jar</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-all</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/bundles/http-all/pom.xml
+++ b/modules/bundles/http-all/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-all</artifactId>
     <packaging>jar</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-all</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/bundles/http-servlet/pom.xml
+++ b/modules/bundles/http-servlet/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-servlet-server</artifactId>
     <packaging>jar</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-http-servlet-server</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/bundles/http-servlet/pom.xml
+++ b/modules/bundles/http-servlet/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-servlet-server</artifactId>
     <packaging>jar</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-http-servlet-server</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/bundles/http/pom.xml
+++ b/modules/bundles/http/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-server-core</artifactId>
     <packaging>jar</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-http-server-core</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/bundles/http/pom.xml
+++ b/modules/bundles/http/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-server-core</artifactId>
     <packaging>jar</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-http-server-core</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/bundles/pom.xml
+++ b/modules/bundles/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-bundles</artifactId>
     <packaging>pom</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-bundles</name>
 
     <modules>

--- a/modules/bundles/pom.xml
+++ b/modules/bundles/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-bundles</artifactId>
     <packaging>pom</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-bundles</name>
 
     <modules>

--- a/modules/bundles/websockets/pom.xml
+++ b/modules/bundles/websockets/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-websockets-server</artifactId>
     <packaging>jar</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-websockets-server</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/bundles/websockets/pom.xml
+++ b/modules/bundles/websockets/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-websockets-server</artifactId>
     <packaging>jar</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-websockets-server</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/comet/pom.xml
+++ b/modules/comet/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-comet</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-comet</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/comet/pom.xml
+++ b/modules/comet/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-comet</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-comet</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/comet/src/test/java/org/glassfish/grizzly/comet/BasicCometTest.java
+++ b/modules/comet/src/test/java/org/glassfish/grizzly/comet/BasicCometTest.java
@@ -124,7 +124,7 @@ public class BasicCometTest extends TestCase {
         s.setSoLinger(false, 0);
         s.setSoTimeout(500);
         OutputStream os = s.getOutputStream();
-        String a = "GET " + alias + " HTTP/1.1\n" + "Host: localhost:" + PORT + "\n\n";
+        String a = "GET " + alias + " HTTP/1.1\r\n" + "Host: localhost:" + PORT + "\r\n\r\n";
         System.out.println("     " + a);
         os.write(a.getBytes());
         os.flush();
@@ -186,11 +186,11 @@ public class BasicCometTest extends TestCase {
         Socket s = new Socket("localhost", PORT);
         s.setSoTimeout(10 * 1000);
         OutputStream os = s.getOutputStream();
-        String cometRequest = "GET " + alias + " HTTP/1.1\nHost: localhost:" + PORT + "\n\n";
-        String staticRequest = "GET /static HTTP/1.1\nHost: localhost:" + PORT + "\n\n";
+        String cometRequest = "GET " + alias + " HTTP/1.1\r\nHost: localhost:" + PORT + "\r\n\r\n";
+        String staticRequest = "GET /static HTTP/1.1\r\nHost: localhost:" + PORT + "\r\n\r\n";
         
         
-        String lastCometRequest = "GET " + alias + " HTTP/1.1\n"+"Host: localhost:" + PORT + "\nConnection: close\n\n";
+        String lastCometRequest = "GET " + alias + " HTTP/1.1\r\n"+"Host: localhost:" + PORT + "\r\nConnection: close\r\n\r\n";
         
         
         String pipelinedRequest1 = cometRequest + staticRequest + cometRequest;
@@ -278,8 +278,8 @@ public class BasicCometTest extends TestCase {
         Socket s = new Socket("localhost", PORT);
         s.setSoTimeout(10 * 1000);
         OutputStream os = s.getOutputStream();
-        String cometRequest = "GET " + alias + " HTTP/1.1\nHost: localhost:" + PORT + "\n\n";
-        String staticRequest = "GET /static HTTP/1.1\nHost: localhost:" + PORT + "\n\n";
+        String cometRequest = "GET " + alias + " HTTP/1.1\r\nHost: localhost:" + PORT + "\r\n\r\n";
+        String staticRequest = "GET /static HTTP/1.1\r\nHost: localhost:" + PORT + "\r\n\r\n";
         
         
         try {

--- a/modules/grizzly/pom.xml
+++ b/modules/grizzly/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-framework</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-framework</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/grizzly/pom.xml
+++ b/modules/grizzly/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-framework</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-framework</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/http-ajp/pom.xml
+++ b/modules/http-ajp/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-ajp</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-http-ajp</name>
     <url>http://grizzly.java.net</url>
     <build>

--- a/modules/http-ajp/pom.xml
+++ b/modules/http-ajp/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-ajp</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-http-ajp</name>
     <url>http://grizzly.java.net</url>
     <build>

--- a/modules/http-server/pom.xml
+++ b/modules/http-server/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-server</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-http-server</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/http-server/pom.xml
+++ b/modules/http-server/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-server</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-http-server</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/http-servlet/pom.xml
+++ b/modules/http-servlet/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-servlet</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-http-servlet</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/http-servlet/pom.xml
+++ b/modules/http-servlet/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-servlet</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-http-servlet</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/http/pom.xml
+++ b/modules/http/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-http</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/http/pom.xml
+++ b/modules/http/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-http</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2010-2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010-2024 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -41,10 +41,12 @@
 package org.glassfish.grizzly.http;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 import org.glassfish.grizzly.Buffer;
 import org.glassfish.grizzly.Connection;
 import org.glassfish.grizzly.Grizzly;
@@ -55,6 +57,7 @@ import org.glassfish.grizzly.http.util.BufferChunk;
 import org.glassfish.grizzly.http.util.ByteChunk;
 import org.glassfish.grizzly.http.util.CacheableDataChunk;
 import org.glassfish.grizzly.http.util.Constants;
+import org.glassfish.grizzly.http.util.CookieHeaderParser;
 import org.glassfish.grizzly.http.util.DataChunk;
 import org.glassfish.grizzly.http.util.Header;
 import org.glassfish.grizzly.http.util.MimeHeaders;
@@ -153,6 +156,16 @@ public abstract class HttpCodecFilter extends HttpBaseFilter
      * @see #setRemoveHandledContentEncodingHeaders
      */
     private boolean removeHandledContentEncodingHeaders = false;
+
+    public static final String STRICT_HEADER_NAME_VALIDATION_RFC_9110 = "org.glassfish.grizzly.http.STRICT_HEADER_NAME_VALIDATION_RFC_9110";
+
+    public static final String STRICT_HEADER_VALUE_VALIDATION_RFC_9110 = "org.glassfish.grizzly.http.STRICT_HEADER_VALUE_VALIDATION_RFC_9110";
+
+    private static final boolean isStrictHeaderNameValidationSet = Boolean.parseBoolean(System.getProperty(STRICT_HEADER_NAME_VALIDATION_RFC_9110));
+
+    private static final boolean isStrictHeaderValueValidationSet = Boolean.parseBoolean(System.getProperty(STRICT_HEADER_VALUE_VALIDATION_RFC_9110));
+
+    private static final String REGEX_RFC_9110_INVALID_CHARACTERS = "(\\\\n)|(\\\\0)|(\\\\r)|(\\\\x00)|(\\\\x0A)|(\\\\x0D)";
     
     /**
      * File cache probes
@@ -829,8 +842,13 @@ public abstract class HttpCodecFilter extends HttpBaseFilter
                     parsingState.subState++;
                 }
                 case 1: { // parse header name
-                    if (!parseHeaderName(httpHeader, mimeHeaders, parsingState, input, end)) {
+                    final int result = parseHeaderName(httpHeader, mimeHeaders, parsingState, input, end);
+                    if (result == -1) {
                         return false;
+                    } else if (result == -2) { // EOL. ignore field-lines
+                        parsingState.subState = 0;
+                        parsingState.start = -1;
+                        return true;
                     }
 
                     parsingState.subState++;
@@ -879,7 +897,7 @@ public abstract class HttpCodecFilter extends HttpBaseFilter
         }
     }
     
-    protected boolean parseHeaderName(final HttpHeader httpHeader,
+    protected int parseHeaderName(final HttpHeader httpHeader,
             final MimeHeaders mimeHeaders, final HeaderParsingState parsingState,
             final byte[] input, final int end) {
         final int arrayOffs = parsingState.arrayOffset;
@@ -898,19 +916,34 @@ public abstract class HttpCodecFilter extends HttpBaseFilter
                 finalizeKnownHeaderNames(httpHeader, parsingState, input,
                         start, offset);
 
-                return true;
+                return 0;
             } else if ((b >= Constants.A) && (b <= Constants.Z)) {
                 if (!preserveHeaderCase) {
                     b -= Constants.LC_OFFSET;
                 }
                 input[offset] =  b;
+            } else if (isStrictHeaderNameValidationSet && b == Constants.CR) {
+                parsingState.offset = offset - arrayOffs;
+                final int eol = checkEOL(parsingState, input, end);
+                if (eol == 0) { // EOL
+                    // the offset is already increased in the check
+                    return -2;
+                } else if (eol == -2) { // not enough data
+                    // by keeping the offset unchanged, we will recheck the EOL at the next opportunity.
+                    break;
+                }
+            }
+
+            if (isStrictHeaderNameValidationSet && !CookieHeaderParser.isToken(b)) {
+                throw new IllegalStateException(
+                        "An invalid character 0x" + Integer.toHexString(b) + " was found in the header name");
             }
 
             offset++;
         }
 
         parsingState.offset = offset - arrayOffs;
-        return false;
+        return -1;
     }
 
     protected static int parseHeaderValue(final HttpHeader httpHeader,
@@ -943,6 +976,10 @@ public abstract class HttpCodecFilter extends HttpBaseFilter
                         parsingState.headerValueStorage.setBytes(input,
                                 arrayOffs + parsingState.start,
                                 arrayOffs + parsingState.checkpoint2);
+                        if (isStrictHeaderValueValidationSet) {
+                            //make validation with regex mode
+                            validateRFC9110Characters(input, arrayOffs + parsingState.start, arrayOffs + parsingState.checkpoint2);
+                        }
                         return 0;
                     }
                 }
@@ -968,6 +1005,30 @@ public abstract class HttpCodecFilter extends HttpBaseFilter
         }
         parsingState.offset = offset - arrayOffs;
         return -1;
+    }
+
+    private static void validateRFC9110Characters(final byte[] headerValueContent, int start, int end) {
+        if (headerValueContent != null) {
+            if (isInvalidCharacterAvailable(start, end, headerValueContent)) {
+                throw new IllegalStateException(
+                        "An invalid character NUL, LF or CR found in the header value: " + headerValueContent.toString());
+            }
+        }
+    }
+
+    /**
+     * This method evaluates the String from the bytes that contains Header Value and validates if contains literal value
+     * of \n, \r or \0 , in case any of those characters are available return true
+     * @param start index of the starting point to extract characters from the byte array
+     * @param end index of the end point to extract characters from the byte array
+     * @param bytesFromByteChunk represents the bytes from the request message to be processed
+     * @return Boolean true if any of those characters are available
+     */
+    private static boolean isInvalidCharacterAvailable(int start, int end, byte[] bytesFromByteChunk) {
+        byte[] bytesFromHeaderValue = Arrays.copyOfRange(bytesFromByteChunk, start, end);
+        String uft8String = new String(bytesFromHeaderValue, StandardCharsets.UTF_8);
+        Pattern pattern = Pattern.compile(REGEX_RFC_9110_INVALID_CHARACTERS);
+        return pattern.matcher(uft8String).find();
     }
     
     private static void finalizeKnownHeaderNames(final HttpHeader httpHeader,
@@ -1113,8 +1174,13 @@ public abstract class HttpCodecFilter extends HttpBaseFilter
                     parsingState.subState++;
                 }
                 case 1: { // parse header name
-                    if (!parseHeaderName(httpHeader, mimeHeaders, parsingState, input)) {
+                    final int result = parseHeaderName(httpHeader, mimeHeaders, parsingState, input);
+                    if (result == -1) {
                         return false;
+                    } else if (result == -2) { // EOL. ignore field-lines
+                        parsingState.subState = 0;
+                        parsingState.start = -1;
+                        return true;
                     }
 
                     parsingState.subState++;
@@ -1160,7 +1226,7 @@ public abstract class HttpCodecFilter extends HttpBaseFilter
         }
     }
     
-    protected boolean parseHeaderName(final HttpHeader httpHeader,
+    protected int parseHeaderName(final HttpHeader httpHeader,
             final MimeHeaders mimeHeaders, final HeaderParsingState parsingState,
             final Buffer input) {
         final int limit = Math.min(input.limit(), parsingState.packetLimit);
@@ -1177,19 +1243,34 @@ public abstract class HttpCodecFilter extends HttpBaseFilter
                 finalizeKnownHeaderNames(httpHeader, parsingState, input,
                         start, offset);
 
-                return true;
+                return 0;
             } else if ((b >= Constants.A) && (b <= Constants.Z)) {
                 if (!preserveHeaderCase) {
                     b -= Constants.LC_OFFSET;
                 }
                 input.put(offset, b);
+            } else if (b == Constants.CR) {
+                parsingState.offset = offset;
+                final int eol = checkEOL(parsingState, input);
+                if (eol == 0) { // EOL
+                    // the offset is already increased in the check
+                    return -2;
+                } else if (eol == -2) { // not enough data
+                    // by keeping the offset unchanged, we will recheck the EOL at the next opportunity.
+                    break;
+                }
+            }
+
+            if (!CookieHeaderParser.isToken(b)) {
+                throw new IllegalStateException(
+                        "An invalid character 0x" + Integer.toHexString(b) + " was found in the header name");
             }
 
             offset++;
         }
 
         parsingState.offset = offset;
-        return false;
+        return -1;
     }
 
     protected static int parseHeaderValue(final HttpHeader httpHeader,

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
@@ -159,9 +159,9 @@ public abstract class HttpCodecFilter extends HttpBaseFilter
 
     public static final String STRICT_HEADER_VALUE_VALIDATION_RFC_9110 = "org.glassfish.grizzly.http.STRICT_HEADER_VALUE_VALIDATION_RFC_9110";
 
-    private static final boolean isStrictHeaderNameValidationSet = Boolean.parseBoolean(System.getProperty(STRICT_HEADER_NAME_VALIDATION_RFC_9110));
+    private static final boolean isStrictHeaderNameValidationSet = Boolean.parseBoolean((System.getProperty(STRICT_HEADER_NAME_VALIDATION_RFC_9110) == null) ? "true" : System.getProperty(STRICT_HEADER_NAME_VALIDATION_RFC_9110));
 
-    private static final boolean isStrictHeaderValueValidationSet = Boolean.parseBoolean(System.getProperty(STRICT_HEADER_VALUE_VALIDATION_RFC_9110));
+    private static final boolean isStrictHeaderValueValidationSet = Boolean.parseBoolean((System.getProperty(STRICT_HEADER_VALUE_VALIDATION_RFC_9110) == null) ? "true": System.getProperty(STRICT_HEADER_VALUE_VALIDATION_RFC_9110));
     
     /**
      * File cache probes
@@ -980,6 +980,11 @@ public abstract class HttpCodecFilter extends HttpBaseFilter
                         parsingState.offset = offset + 2 - arrayOffs;
                         return -2;
                     } else {
+                        final byte b3 = input[offset - 1];
+                        if (!(b3 == Constants.CR) && isStrictHeaderValueValidationSet) {
+                            throw new IllegalStateException(
+                                    "An invalid character 0x" + Integer.toHexString(b) + " was found in the header value");
+                        }
                         parsingState.offset = offset + 1 - arrayOffs;
                         finalizeKnownHeaderValues(httpHeader, parsingState, input,
                                 arrayOffs + parsingState.start,
@@ -1296,6 +1301,11 @@ public abstract class HttpCodecFilter extends HttpBaseFilter
                         parsingState.offset = offset + 2;
                         return -2;
                     } else {
+                        final byte b3 = input.get(offset - 1);
+                        if (!(b3 == Constants.CR) && isStrictHeaderValueValidationSet) {
+                            throw new IllegalStateException(
+                                    "An invalid character 0x" + Integer.toHexString(b) + " was found in the header value");
+                        }
                         parsingState.offset = offset + 1;
                         finalizeKnownHeaderValues(httpHeader, parsingState, input,
                                 parsingState.start, parsingState.checkpoint2);

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/util/CookieHeaderParser.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/util/CookieHeaderParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  * Copyright 2004, 2022 The Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -247,7 +247,15 @@ public class CookieHeaderParser {
         }
     }
 
-
+    public static boolean isText(int c) {
+        // Fast for correct values, slower for incorrect ones
+        try {
+            return isText[c];
+        } catch (ArrayIndexOutOfBoundsException ex) {
+            return false;
+        }
+    }
+    
     /**
      * Custom implementation that skips many of the safety checks in
      * {@link java.nio.ByteBuffer}.

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/util/CookieHeaderParser.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/util/CookieHeaderParser.java
@@ -1,0 +1,311 @@
+/*
+ * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation
+ * Copyright 2004, 2022 The Apache Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glassfish.grizzly.http.util;
+
+import org.glassfish.grizzly.http.Cookies;
+import org.glassfish.grizzly.http.LazyCookieState;
+
+/**
+ * <p>Cookie header parser based on RFC6265</p>
+ * <p>The parsing of cookies using RFC6265 is more relaxed that the
+ * specification in the following ways:</p>
+ * <ul>
+ *   <li>Values 0x80 to 0xFF are permitted in cookie-octet to support the use of
+ *       UTF-8 in cookie values as used by HTML 5.</li>
+ *   <li>For cookies without a value, the '=' is not required after the name as
+ *       some browsers do not sent it.</li>
+ * </ul>
+ *
+ * <p>Implementation note:<br>
+ * This class has been carefully tuned. </p>
+ *
+ * @author The Tomcat team
+ * @author Arjan Tijms
+ */
+public class CookieHeaderParser {
+
+    private static final boolean isCookieOctet[] = new boolean[256];
+    private static final boolean isText[] = new boolean[256];
+    private static final byte[] EMPTY_BYTES = new byte[0];
+    private static final byte TAB_BYTE = (byte) 0x09;
+    private static final byte SPACE_BYTE = (byte) 0x20;
+    private static final byte QUOTE_BYTE = (byte) 0x22;
+    private static final byte COMMA_BYTE = (byte) 0x2C;
+    private static final byte SEMICOLON_BYTE = (byte) 0x3B;
+    private static final byte EQUALS_BYTE = (byte) 0x3D;
+    private static final byte SLASH_BYTE = (byte) 0x5C;
+    private static final byte DEL_BYTE = (byte) 0x7F;
+
+    private static final int ARRAY_SIZE = 128;
+    private static final boolean[] IS_CONTROL = new boolean[ARRAY_SIZE];
+    private static final boolean[] IS_SEPARATOR = new boolean[ARRAY_SIZE];
+    private static final boolean[] IS_TOKEN = new boolean[ARRAY_SIZE];
+
+    static {
+        // %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E (RFC6265)
+        // %x80 to %xFF                                 (UTF-8)
+        for (int i = 0; i < 256; i++) {
+            if (i < 0x21 || i == QUOTE_BYTE || i == COMMA_BYTE || i == SEMICOLON_BYTE || i == SLASH_BYTE || i == DEL_BYTE) {
+                isCookieOctet[i] = false;
+            } else {
+                isCookieOctet[i] = true;
+            }
+        }
+
+        for (int i = 0; i < 256; i++) {
+            if (i < TAB_BYTE || (i > TAB_BYTE && i < SPACE_BYTE) || i == DEL_BYTE) {
+                isText[i] = false;
+            } else {
+                isText[i] = true;
+            }
+        }
+
+        for (int i = 0; i < ARRAY_SIZE; i++) {
+            // Control> 0-31, 127
+            if (i < 32 || i == 127) {
+                IS_CONTROL[i] = true;
+            }
+
+            // Separator
+            if (i == '(' || i == ')' || i == '<' || i == '>' || i == '@' ||
+                    i == ',' || i == ';' || i == ':' || i == '\\' || i == '\"' ||
+                    i == '/' || i == '[' || i == ']' || i == '?' || i == '=' ||
+                    i == '{' || i == '}' || i == ' ' || i == '\t') {
+                IS_SEPARATOR[i] = true;
+            }
+
+            // Token: Anything 0-127 that is not a control and not a separator
+            if (!IS_CONTROL[i] && !IS_SEPARATOR[i] && i < 128) {
+                IS_TOKEN[i] = true;
+            }
+        }
+    }
+
+
+    private CookieHeaderParser() {
+        // Hide default constructor
+    }
+
+
+    public static void parseCookie(byte[] bytes, int offset, int len, Cookies serverCookies) {
+
+        // ByteBuffer is used throughout this parser as it allows the byte[]
+        // and position information to be easily passed between parsing methods
+        ByteBuffer byteBuffer = new ByteBuffer(bytes, offset, len);
+
+        boolean moreToProcess = true;
+
+        while (moreToProcess) {
+            skipWhiteSpace(byteBuffer);
+
+            ByteBuffer name = readToken(byteBuffer);
+            ByteBuffer value = null;
+
+            skipWhiteSpace(byteBuffer);
+
+            SkipResult skipResult = skipByte(byteBuffer, EQUALS_BYTE);
+            if (skipResult == SkipResult.FOUND) {
+                skipWhiteSpace(byteBuffer);
+                value = readCookieValueRfc6265(byteBuffer);
+                if (value == null) {
+                    // Invalid cookie value. Skip to the next semi-colon
+                    skipUntilSemiColon(byteBuffer);
+                    continue;
+                }
+                skipWhiteSpace(byteBuffer);
+            }
+
+            skipResult = skipByte(byteBuffer, SEMICOLON_BYTE);
+            if (skipResult == SkipResult.FOUND) {
+                // NO-OP
+            } else if (skipResult == SkipResult.NOT_FOUND) {
+                // Invalid cookie. Ignore it and skip to the next semi-colon
+                skipUntilSemiColon(byteBuffer);
+                continue;
+            } else {
+                // SkipResult.EOF
+                moreToProcess = false;
+            }
+
+            if (name.hasRemaining()) {
+                LazyCookieState lazyCookie = serverCookies.getNextUnusedCookie().getLazyCookieState();
+                lazyCookie.getName().setBytes(name.array(), name.position(), name.position() + name.remaining());
+                if (value == null) {
+                    lazyCookie.getValue().setBytes(EMPTY_BYTES, 0, EMPTY_BYTES.length);
+                } else {
+                    lazyCookie.getValue().setBytes(value.array(), value.position(), value.position() + value.remaining());
+                }
+            }
+        }
+    }
+
+
+    private static void skipWhiteSpace(ByteBuffer byteBuffer) {
+        while (byteBuffer.hasRemaining()) {
+            byte b = byteBuffer.get();
+            if (b != TAB_BYTE && b != SPACE_BYTE) {
+                byteBuffer.rewind();
+                break;
+            }
+        }
+    }
+
+
+    private static void skipUntilSemiColon(ByteBuffer byteBuffer) {
+        while (byteBuffer.hasRemaining()) {
+            if (byteBuffer.get() == SEMICOLON_BYTE) {
+                break;
+            }
+        }
+    }
+
+
+    private static SkipResult skipByte(ByteBuffer byteBuffer, byte target) {
+        if (!byteBuffer.hasRemaining()) {
+            return SkipResult.EOF;
+        }
+        if (byteBuffer.get() == target) {
+            return SkipResult.FOUND;
+        }
+
+        byteBuffer.rewind();
+        return SkipResult.NOT_FOUND;
+    }
+
+
+    /**
+     * Similar to readCookieValue() but treats a comma as part of an invalid
+     * value.
+     */
+    private static ByteBuffer readCookieValueRfc6265(ByteBuffer byteBuffer) {
+        boolean quoted = false;
+        if (byteBuffer.hasRemaining()) {
+            if (byteBuffer.get() == QUOTE_BYTE) {
+                quoted = true;
+            } else {
+                byteBuffer.rewind();
+            }
+        }
+
+        int start = byteBuffer.position();
+        int end = byteBuffer.limit();
+        while (byteBuffer.hasRemaining()) {
+            byte b = byteBuffer.get();
+            if (isCookieOctet[(b & 0xFF)]) {
+                // NO-OP
+            } else if (b == SEMICOLON_BYTE || b == SPACE_BYTE || b == TAB_BYTE) {
+                end = byteBuffer.position() - 1;
+                byteBuffer.position(end);
+                break;
+            } else if (quoted && b == QUOTE_BYTE) {
+                end = byteBuffer.position() - 1;
+                break;
+            } else {
+                // Invalid cookie
+                return null;
+            }
+        }
+
+        return new ByteBuffer(byteBuffer.bytes, start, end - start);
+    }
+
+
+    private static ByteBuffer readToken(ByteBuffer byteBuffer) {
+        final int start = byteBuffer.position();
+        int end = byteBuffer.limit();
+        while (byteBuffer.hasRemaining()) {
+            if (!isToken(byteBuffer.get())) {
+                end = byteBuffer.position() - 1;
+                byteBuffer.position(end);
+                break;
+            }
+        }
+
+        return new ByteBuffer(byteBuffer.bytes, start, end - start);
+    }
+
+    public static boolean isToken(int c) {
+        // Fast for correct values, slower for incorrect ones
+        try {
+            return IS_TOKEN[c];
+        } catch (ArrayIndexOutOfBoundsException ex) {
+            return false;
+        }
+    }
+
+
+    /**
+     * Custom implementation that skips many of the safety checks in
+     * {@link java.nio.ByteBuffer}.
+     */
+    private static class ByteBuffer {
+
+        private final byte[] bytes;
+        private int limit;
+        private int position = 0;
+
+        public ByteBuffer(byte[] bytes, int offset, int len) {
+            this.bytes = bytes;
+            this.position = offset;
+            this.limit = offset + len;
+        }
+
+        public int position() {
+            return position;
+        }
+
+        public void position(int position) {
+            this.position = position;
+        }
+
+        public int limit() {
+            return limit;
+        }
+
+        public int remaining() {
+            return limit - position;
+        }
+
+        public boolean hasRemaining() {
+            return position < limit;
+        }
+
+        public byte get() {
+            return bytes[position++];
+        }
+
+        public void rewind() {
+            position--;
+        }
+
+        public byte[] array() {
+            return bytes;
+        }
+
+        // For debug purposes
+        @Override
+        public String toString() {
+            return "position [" + position + "], limit [" + limit + "]";
+        }
+    }
+
+    private static enum SkipResult {
+        FOUND,
+        NOT_FOUND,
+        EOF
+    }
+}

--- a/modules/http/src/test/java/org/glassfish/grizzly/http/ChunkedTransferEncodingTest.java
+++ b/modules/http/src/test/java/org/glassfish/grizzly/http/ChunkedTransferEncodingTest.java
@@ -168,7 +168,7 @@ public class ChunkedTransferEncodingTest {
     }
 
     public ChunkedTransferEncodingTest(String eol, boolean isChunkWhenParsing) {
-        this.eol = eol;
+        this.eol = "\r\n";
         this.isChunkWhenParsing = isChunkWhenParsing;
     }
         

--- a/modules/http/src/test/java/org/glassfish/grizzly/http/HttpRequestParseTest.java
+++ b/modules/http/src/test/java/org/glassfish/grizzly/http/HttpRequestParseTest.java
@@ -149,6 +149,15 @@ public class HttpRequestParseTest extends TestCase {
     }
 
     public void testDisallowedCharactersForHeaderContentValues() {
+        final StringBuilder sb = new StringBuilder("GET / HTTP/1.1\r\n");
+        sb.append("Host: localhost\r\n");
+        sb.append("Some-Header: some-");
+        // valid header values
+        sb.append(new char[]{'\t', ' ', '\"', '(', ')', '/', ';', '<', '=', '>', '?', '@', '[', 0x5c, ']', '{', '}'})
+                .append("\r\n");
+        sb.append("\r\n");
+        doTestDecoder(sb.toString(), 128);
+
         try {
             doTestDecoder("GET /index.html HTTP/1.1\nHost: loca\\rlhost\nContent -Length: 1234\n\n", 128);
             fail("Bad HTTP headers exception had to be thrown");
@@ -166,6 +175,16 @@ public class HttpRequestParseTest extends TestCase {
             fail("Bad HTTP headers exception had to be thrown");
         } catch (IllegalStateException e) {
             // expected
+        }
+
+        final char[] invalidChars = new char[]{0x00, 0x01, 0x02, '\r'};
+        for (final char ch : invalidChars) {
+            try {
+                doTestDecoder("GET /index.html HTTP/1.1\nHost: localhost\nSome-Header: some-" + ch + "value\n\n", 128);
+                fail("Bad HTTP headers exception had to be thrown");
+            } catch (IllegalStateException e) {
+                // expected
+            }
         }
     }
 

--- a/modules/http/src/test/java/org/glassfish/grizzly/http/HttpRequestParseTest.java
+++ b/modules/http/src/test/java/org/glassfish/grizzly/http/HttpRequestParseTest.java
@@ -211,9 +211,9 @@ public class HttpRequestParseTest extends TestCase {
         Map<String, Pair<String, String>> headers =
                 new HashMap<String, Pair<String, String>>();
         headers.put("Host", new Pair<String,String>("localhost", "localhost"));
-        headers.put("Multi-line", new Pair<String,String>("first\r\n          second\n       third", "first second third"));
+        headers.put("Multi-line", new Pair<String,String>("first\r\n          second\r\n       third", "first second third"));
         headers.put("Content-length", new Pair<String,String>("2345", "2345"));
-        doHttpRequestTest("POST", "/index.html", "HTTP/1.1", headers, "\n");
+        doHttpRequestTest("POST", "/index.html", "HTTP/1.1", headers, "\r\n");
     }
 
     public void testCompleteURI() throws Exception {
@@ -223,7 +223,7 @@ public class HttpRequestParseTest extends TestCase {
         headers.put("Content-length", new Pair<String,String>("2345", "2345"));
         doHttpRequestTest(new Pair<String, String>("POST", "POST"),
                 new Pair<String, String>("http://localhost:8180/index.html", "/index.html"),
-                new Pair<String,String>("HTTP/1.1", "HTTP/1.1"), headers, "\n", false);
+                new Pair<String,String>("HTTP/1.1", "HTTP/1.1"), headers, "\r\n", false);
     }
 
     public void testCompleteEmptyURI() throws Exception {
@@ -233,7 +233,7 @@ public class HttpRequestParseTest extends TestCase {
         headers.put("Content-length", new Pair<String,String>("2345", "2345"));
         doHttpRequestTest(new Pair<String, String>("POST", "POST"),
                 new Pair<String, String>("http://localhost:8180", "/"),
-                new Pair<String,String>("HTTP/1.1", "HTTP/1.1"), headers, "\n", false);
+                new Pair<String,String>("HTTP/1.1", "HTTP/1.1"), headers, "\r\n", false);
     }
 
     public void testDecoderOK() {
@@ -277,7 +277,7 @@ public class HttpRequestParseTest extends TestCase {
     }
 
     public void testDecoderOverflowHeader2() {
-        doTestDecoder("GET /index.html HTTP/1.0\nHost: localhost\n\n", 42);
+        doTestDecoder("GET /index.html HTTP/1.0\r\nHost: localhost\r\n\r\n", 50);
     }
     
     public void testDecoderOverflowHeader3() {
@@ -295,7 +295,7 @@ public class HttpRequestParseTest extends TestCase {
     
     public void testChunkedTransferEncodingCaseInsensitive() {
         HttpPacket packet = doTestDecoder(
-                "POST /index.html HTTP/1.1\nHost: localhost\nTransfer-Encoding: CHUNked\r\n\r\n", 4096);
+                "POST /index.html HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: CHUNked\r\n\r\n", 4096);
         assertTrue(packet.getHttpHeader().isChunked());
     }
     

--- a/modules/http/src/test/java/org/glassfish/grizzly/http/HttpResponseParseTest.java
+++ b/modules/http/src/test/java/org/glassfish/grizzly/http/HttpResponseParseTest.java
@@ -111,7 +111,7 @@ public class HttpResponseParseTest extends TestCase {
         headers.put("Header1", new Pair<String, String>("localhost", "localhost"));
         headers.put("Multi-line", new Pair<String, String>("first\n          second\n       third", "first seconds third"));
         headers.put("Content-length", new Pair<String, String>("2345", "2345"));
-        doHttpResponseTest("HTTP/1.0", 200, "DONE", headers, "\n");
+        doHttpResponseTest("HTTP/1.0", 200, "DONE", headers, "\r\n");
     }
 
     public void testDecoderOK() {

--- a/modules/http/src/test/java/org/glassfish/grizzly/http/HttpSemanticsTest.java
+++ b/modules/http/src/test/java/org/glassfish/grizzly/http/HttpSemanticsTest.java
@@ -841,9 +841,9 @@ public class HttpSemanticsTest extends TestCase {
                 TCPNIOTransportBuilder.newInstance().build(), null);
         
         Buffer requestBuf = Buffers.wrap(connection.getMemoryManager(),
-                "GET /path HTTP/1.1\n"
-                        + "Host: localhost:" + PORT + '\n'
-                        + '\n');
+                "GET /path HTTP/1.1\r\n"
+                        + "Host: localhost:" + PORT + "\r\n"
+                        + "\r\n");
         
         FilterChainContext ctx = FilterChainContext.create(connection);
         ctx.setMessage(requestBuf);

--- a/modules/monitoring/grizzly/pom.xml
+++ b/modules/monitoring/grizzly/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-framework-monitoring</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-framework-monitoring</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/monitoring/grizzly/pom.xml
+++ b/modules/monitoring/grizzly/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-framework-monitoring</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-framework-monitoring</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/monitoring/http-server/pom.xml
+++ b/modules/monitoring/http-server/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-server-monitoring</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-http-server-monitoring</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/monitoring/http-server/pom.xml
+++ b/modules/monitoring/http-server/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-server-monitoring</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-http-server-monitoring</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/monitoring/http/pom.xml
+++ b/modules/monitoring/http/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-monitoring</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-http-monitoring</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/monitoring/http/pom.xml
+++ b/modules/monitoring/http/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-http-monitoring</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-http-monitoring</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/monitoring/pom.xml
+++ b/modules/monitoring/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-monitoring</artifactId>
     <packaging>pom</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-monitoring</name>
     <modules>
         <module>grizzly</module>

--- a/modules/monitoring/pom.xml
+++ b/modules/monitoring/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-monitoring</artifactId>
     <packaging>pom</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-monitoring</name>
     <modules>
         <module>grizzly</module>

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-modules</artifactId>
     <packaging>pom</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-modules</name>
     <profiles>
         <profile>

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-modules</artifactId>
     <packaging>pom</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-modules</name>
     <profiles>
         <profile>

--- a/modules/portunif/pom.xml
+++ b/modules/portunif/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-portunif</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-portunif</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/portunif/pom.xml
+++ b/modules/portunif/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-portunif</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-portunif</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/spdy/pom.xml
+++ b/modules/spdy/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-spdy</artifactId>
     <!--<packaging>bundle</packaging>-->
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-spdy</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/spdy/pom.xml
+++ b/modules/spdy/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-spdy</artifactId>
     <!--<packaging>bundle</packaging>-->
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-spdy</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/websockets/pom.xml
+++ b/modules/websockets/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-websockets</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-websockets</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/modules/websockets/pom.xml
+++ b/modules/websockets/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>grizzly-websockets</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-websockets</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-bom</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>bom/pom.xml</relativePath>
     </parent>
 
@@ -52,7 +52,7 @@
     <artifactId>grizzly-project</artifactId>
     <packaging>pom</packaging>
     <name>grizzly-project</name>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <url>http://grizzly.java.net</url>
     <issueManagement>
         <system>GitHub</system>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-bom</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>bom/pom.xml</relativePath>
     </parent>
 
@@ -52,7 +52,7 @@
     <artifactId>grizzly-project</artifactId>
     <packaging>pom</packaging>
     <name>grizzly-project</name>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <url>http://grizzly.java.net</url>
     <issueManagement>
         <system>GitHub</system>
@@ -155,6 +155,14 @@
         <directory>target</directory>
         <finalName>${project.artifactId}-${project.version}</finalName>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>

--- a/samples/comet/comet-counter/pom.xml
+++ b/samples/comet/comet-counter/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-comet-counter</artifactId>
     <packaging>war</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-comet-counter</name>
     <url>https://grizzly.java.net</url>
     <dependencies>

--- a/samples/comet/comet-counter/pom.xml
+++ b/samples/comet/comet-counter/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-comet-counter</artifactId>
     <packaging>war</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-comet-counter</name>
     <url>https://grizzly.java.net</url>
     <dependencies>

--- a/samples/comet/pom.xml
+++ b/samples/comet/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-comet-samples</artifactId>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-comet-samples</name>
 
     <packaging>pom</packaging>

--- a/samples/comet/pom.xml
+++ b/samples/comet/pom.xml
@@ -45,13 +45,13 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-comet-samples</artifactId>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-comet-samples</name>
 
     <packaging>pom</packaging>

--- a/samples/connection-pool-samples/pom.xml
+++ b/samples/connection-pool-samples/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>connection-pool-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>connection-pool-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/connection-pool-samples/pom.xml
+++ b/samples/connection-pool-samples/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>connection-pool-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>connection-pool-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/framework-samples/pom.xml
+++ b/samples/framework-samples/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
      <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-framework-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-framework-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/framework-samples/pom.xml
+++ b/samples/framework-samples/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
      <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-framework-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-framework-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/http-ajp-samples/pom.xml
+++ b/samples/http-ajp-samples/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
      <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-http-ajp-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-http-ajp-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/http-ajp-samples/pom.xml
+++ b/samples/http-ajp-samples/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
      <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-http-ajp-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-http-ajp-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/http-jaxws-samples/pom.xml
+++ b/samples/http-jaxws-samples/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-http-jaxws-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-http-jaxws-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/http-jaxws-samples/pom.xml
+++ b/samples/http-jaxws-samples/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-http-jaxws-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-http-jaxws-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/http-multipart-samples/pom.xml
+++ b/samples/http-multipart-samples/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-http-multipart-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-http-multipart-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/http-multipart-samples/pom.xml
+++ b/samples/http-multipart-samples/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-http-multipart-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-http-multipart-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/http-samples/pom.xml
+++ b/samples/http-samples/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-http-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-http-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/http-samples/pom.xml
+++ b/samples/http-samples/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-http-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-http-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/http-server-samples/pom.xml
+++ b/samples/http-server-samples/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-http-server-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-http-server-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/http-server-samples/pom.xml
+++ b/samples/http-server-samples/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-http-server-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-http-server-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-samples</artifactId>
     <packaging>pom</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-samples</name>
     <modules>
         <module>framework-samples</module>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-samples</artifactId>
     <packaging>pom</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-samples</name>
     <modules>
         <module>framework-samples</module>

--- a/samples/portunif/pom.xml
+++ b/samples/portunif/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
      <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-portunif-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-portunif-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/portunif/pom.xml
+++ b/samples/portunif/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
      <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-portunif-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-portunif-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/spdy-samples/pom.xml
+++ b/samples/spdy-samples/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-spdy-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-spdy-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/spdy-samples/pom.xml
+++ b/samples/spdy-samples/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-spdy-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-spdy-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/tls-sni-samples/pom.xml
+++ b/samples/tls-sni-samples/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-tls-sni-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-tls-sni-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/tls-sni-samples/pom.xml
+++ b/samples/tls-sni-samples/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-tls-sni-samples</artifactId>
     <packaging>bundle</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-tls-sni-samples</name>
     <build>
         <defaultGoal>install</defaultGoal>

--- a/samples/websockets/chat-ssl/pom.xml
+++ b/samples/websockets/chat-ssl/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-websockets-chat-ssl</artifactId>
     <packaging>war</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-websockets-chat-ssl</name>
     <url>http://maven.apache.org</url>
     <build>

--- a/samples/websockets/chat-ssl/pom.xml
+++ b/samples/websockets/chat-ssl/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-websockets-chat-ssl</artifactId>
     <packaging>war</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-websockets-chat-ssl</name>
     <url>http://maven.apache.org</url>
     <build>

--- a/samples/websockets/chat/pom.xml
+++ b/samples/websockets/chat/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p4</version>
+        <version>2.3.31.payara-p5</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-websockets-chat</artifactId>
     <packaging>war</packaging>
-    <version>2.3.31.payara-p4</version>
+    <version>2.3.31.payara-p5</version>
     <name>grizzly-websockets-chat</name>
     <url>http://maven.apache.org</url>
     <build>

--- a/samples/websockets/chat/pom.xml
+++ b/samples/websockets/chat/pom.xml
@@ -45,14 +45,14 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>2.3.31.payara-p5</version>
+        <version>2.3.31.payara-p5-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.grizzly.samples</groupId>
     <artifactId>grizzly-websockets-chat</artifactId>
     <packaging>war</packaging>
-    <version>2.3.31.payara-p5</version>
+    <version>2.3.31.payara-p5-SNAPSHOT</version>
     <name>grizzly-websockets-chat</name>
     <url>http://maven.apache.org</url>
     <build>


### PR DESCRIPTION
This is a PR to include new properties on the grizzly implementation to enable Header Name and Header Value validation against invalid characters mentioned on the RFC-9110, here the reference of the reported issue: [Glassfish issue](https://github.com/eclipse-ee4j/glassfish/issues/25128 ) and here the reserved CVE [CVE-2024-45687](https://www.cve.org/CVERecord?id=CVE-2024-45687)

To test this set the dependency version on the payara server: 2.3.31.payara-p5 build and run
deploy the following reproducer: 
[MinimalTest.zip](https://github.com/user-attachments/files/17726621/MinimalTest.zip)



By default grizzly is setting two new properties that enable the validation of the headers by default. You can customize this behavior by seeting the following properties from UI or by cli command o directly on the domain.xml file

- -Dorg.glassfish.grizzly.http.STRICT_HEADER_NAME_VALIDATION_RFC_9110=true
- -Dorg.glassfish.grizzly.http.STRICT_HEADER_VALUE_VALIDATION_RFC_9110=true

![image](https://github.com/user-attachments/assets/8b964374-84f0-4edb-8479-7062a564466e)


`
asadmin create-jvm-options --target=server-config "-Dorg.glassfish.grizzly.http.STRICT_HEADER_NAME_VALIDATION_RFC_9110\=true"
`

`
asadmin create-jvm-options --target=server-config "-Dorg.glassfish.grizzly.http.STRICT_HEADER_VALUE_VALIDATION_RFC_9110\=true"
`

after adding the properties you need to restart the server

by default on the grizzly side those properties are set as true

deploy the reproducer and make curl calls

Header Name Validation tests:

-  curl -i -v -H $'X-MyHeader\n: hello' http://localhost:8080/MinimalTest/
- curl -i -v -H $'X-MyHeader\r: hello' http://localhost:8080/MinimalTest/

the result of any of those test should be error 400:

![image](https://github.com/user-attachments/assets/ba616cd7-41fe-47c8-9dfb-a6c76c6b26a0)

The following request will return 200 but the \0 will be removed and not accepted :

- curl -i -v -H $'X-MyHeader\0: hello' http://localhost:8080/MinimalTest/

![image](https://github.com/user-attachments/assets/eb196772-3587-400d-8d5a-943dc5596d60)

Header Value Validations tests:
- curl -i -v -H $'X-MyHeader: he\nllo' http://localhost:8080/MinimalTest/

![image](https://github.com/user-attachments/assets/e61bf892-5e59-4c84-92ba-9ef036f10a2f)

- curl -i -v -H $'X-MyHeader: he\rllo' http://localhost:8080/MinimalTest/
![image](https://github.com/user-attachments/assets/da9a02f5-e6a1-4dca-9c7e-90a584ae3447)

- curl -i -v -H $'X-MyHeader: he\0llo' http://localhost:8080/MinimalTest/
![image](https://github.com/user-attachments/assets/71b51dab-e799-4cd6-b4a1-8b5122c8d67b)

The \0 is immediately not processed from curl because by default we can't consider that character on the request headers and the the \r and \n characters are not permitted alone on the header value content

