### PR TITLE
Fish 9690 filtering incorrect characters header validation rfc 9110

### DIFF
--- a/boms/bom/pom.xml
+++ b/boms/bom/pom.xml
@@ -30,7 +30,7 @@
 
     <groupId>org.glassfish.grizzly</groupId>
     <artifactId>grizzly-bom</artifactId>
-    <version>4.0.0.payara-p1</version>
+    <version>4.0.2.payara-p2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>grizzly-bom</name>

--- a/boms/bom/pom.xml
+++ b/boms/bom/pom.xml
@@ -30,7 +30,7 @@
 
     <groupId>org.glassfish.grizzly</groupId>
     <artifactId>grizzly-bom</artifactId>
-    <version>4.0.2.payara-p2-SNAPSHOT</version>
+    <version>4.0.0.payara-p2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>grizzly-bom</name>

--- a/boms/bom/pom.xml
+++ b/boms/bom/pom.xml
@@ -234,4 +234,67 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>patched-project-release</id>
+            <distributionManagement>
+                <repository>
+                    <id>payara-nexus-artifacts</id>
+                    <url>https://nexus.dev.payara.fish/repository/payara-artifacts/</url>
+                </repository>
+                <snapshotRepository>
+                    <id>payara-nexus-snapshots</id>
+                    <url>https://nexus.dev.payara.fish/repository/payara-snapshots/</url>
+                </snapshotRepository>
+            </distributionManagement>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <configuration>
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/extras/bundles/grizzly-httpservice-bundle/pom.xml
+++ b/extras/bundles/grizzly-httpservice-bundle/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/extras/bundles/grizzly-httpservice-bundle/pom.xml
+++ b/extras/bundles/grizzly-httpservice-bundle/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/extras/bundles/pom.xml
+++ b/extras/bundles/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extras/bundles/pom.xml
+++ b/extras/bundles/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extras/connection-pool/pom.xml
+++ b/extras/connection-pool/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extras/connection-pool/pom.xml
+++ b/extras/connection-pool/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extras/grizzly-httpservice/pom.xml
+++ b/extras/grizzly-httpservice/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extras/grizzly-httpservice/pom.xml
+++ b/extras/grizzly-httpservice/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extras/http-server-jaxws/pom.xml
+++ b/extras/http-server-jaxws/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extras/http-server-jaxws/pom.xml
+++ b/extras/http-server-jaxws/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extras/http-server-multipart/pom.xml
+++ b/extras/http-server-multipart/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extras/http-server-multipart/pom.xml
+++ b/extras/http-server-multipart/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extras/http-servlet-extras/pom.xml
+++ b/extras/http-servlet-extras/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extras/http-servlet-extras/pom.xml
+++ b/extras/http-servlet-extras/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extras/pom.xml
+++ b/extras/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/extras/pom.xml
+++ b/extras/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/extras/tls-sni/pom.xml
+++ b/extras/tls-sni/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/extras/tls-sni/pom.xml
+++ b/extras/tls-sni/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/bundles/comet/pom.xml
+++ b/modules/bundles/comet/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/modules/bundles/comet/pom.xml
+++ b/modules/bundles/comet/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/modules/bundles/core/pom.xml
+++ b/modules/bundles/core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/modules/bundles/core/pom.xml
+++ b/modules/bundles/core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/modules/bundles/http-all/pom.xml
+++ b/modules/bundles/http-all/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/modules/bundles/http-all/pom.xml
+++ b/modules/bundles/http-all/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/modules/bundles/http-servlet/pom.xml
+++ b/modules/bundles/http-servlet/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/modules/bundles/http-servlet/pom.xml
+++ b/modules/bundles/http-servlet/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/modules/bundles/http/pom.xml
+++ b/modules/bundles/http/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/modules/bundles/http/pom.xml
+++ b/modules/bundles/http/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/modules/bundles/pom.xml
+++ b/modules/bundles/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/bundles/pom.xml
+++ b/modules/bundles/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/bundles/websockets/pom.xml
+++ b/modules/bundles/websockets/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/modules/bundles/websockets/pom.xml
+++ b/modules/bundles/websockets/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/modules/comet/pom.xml
+++ b/modules/comet/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/comet/pom.xml
+++ b/modules/comet/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/comet/src/test/java/org/glassfish/grizzly/comet/BasicCometTest.java
+++ b/modules/comet/src/test/java/org/glassfish/grizzly/comet/BasicCometTest.java
@@ -105,7 +105,7 @@ public class BasicCometTest extends TestCase {
         s.setSoLinger(false, 0);
         s.setSoTimeout(500);
         OutputStream os = s.getOutputStream();
-        String a = "GET " + alias + " HTTP/1.1\n" + "Host: localhost:" + PORT + "\n\n";
+        String a = "GET " + alias + " HTTP/1.1\r\n" + "Host: localhost:" + PORT + "\r\n\r\n";
         System.out.println("     " + a);
         os.write(a.getBytes());
         os.flush();
@@ -167,10 +167,10 @@ public class BasicCometTest extends TestCase {
         Socket s = new Socket("localhost", PORT);
         s.setSoTimeout(10 * 1000);
         OutputStream os = s.getOutputStream();
-        String cometRequest = "GET " + alias + " HTTP/1.1\nHost: localhost:" + PORT + "\n\n";
-        String staticRequest = "GET /static HTTP/1.1\nHost: localhost:" + PORT + "\n\n";
+        String cometRequest = "GET " + alias + " HTTP/1.1\r\nHost: localhost:" + PORT + "\r\n\r\n";
+        String staticRequest = "GET /static HTTP/1.1\r\nHost: localhost:" + PORT + "\r\n\r\n";
 
-        String lastCometRequest = "GET " + alias + " HTTP/1.1\n" + "Host: localhost:" + PORT + "\nConnection: close\n\n";
+        String lastCometRequest = "GET " + alias + " HTTP/1.1\r\n" + "Host: localhost:" + PORT + "\r\nConnection: close\r\n\r\n";
 
         String pipelinedRequest1 = cometRequest + staticRequest + cometRequest;
         String pipelinedRequest2 = cometRequest + staticRequest + lastCometRequest;
@@ -256,8 +256,8 @@ public class BasicCometTest extends TestCase {
         Socket s = new Socket("localhost", PORT);
         s.setSoTimeout(10 * 1000);
         OutputStream os = s.getOutputStream();
-        String cometRequest = "GET " + alias + " HTTP/1.1\nHost: localhost:" + PORT + "\n\n";
-        String staticRequest = "GET /static HTTP/1.1\nHost: localhost:" + PORT + "\n\n";
+        String cometRequest = "GET " + alias + " HTTP/1.1\r\nHost: localhost:" + PORT + "\r\n\r\n";
+        String staticRequest = "GET /static HTTP/1.1\r\nHost: localhost:" + PORT + "\r\n\r\n";
 
         try {
             os.write(cometRequest.getBytes());

--- a/modules/grizzly/pom.xml
+++ b/modules/grizzly/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/grizzly/pom.xml
+++ b/modules/grizzly/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/http-ajp/pom.xml
+++ b/modules/http-ajp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/http-ajp/pom.xml
+++ b/modules/http-ajp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/http-server/pom.xml
+++ b/modules/http-server/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/http-server/pom.xml
+++ b/modules/http-server/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/http-servlet/pom.xml
+++ b/modules/http-servlet/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/http-servlet/pom.xml
+++ b/modules/http-servlet/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/http/pom.xml
+++ b/modules/http/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/http/pom.xml
+++ b/modules/http/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
@@ -113,9 +113,9 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
      */
     private boolean removeHandledContentEncodingHeaders = false;
     
-    private static final String STRICT_HEADER_NAME_VALIDATION_RFC_9110 = "org.glassfish.grizzly.http.STRICT_HEADER_NAME_VALIDATION_RFC_9110";
+    public static final String STRICT_HEADER_NAME_VALIDATION_RFC_9110 = "org.glassfish.grizzly.http.STRICT_HEADER_NAME_VALIDATION_RFC_9110";
     
-    private static final String STRICT_HEADER_VALUE_VALIDATION_RFC_9110 = "org.glassfish.grizzly.http.STRICT_HEADER_VALUE_VALIDATION_RFC_9110";
+    public static final String STRICT_HEADER_VALUE_VALIDATION_RFC_9110 = "org.glassfish.grizzly.http.STRICT_HEADER_VALUE_VALIDATION_RFC_9110";
     
     private static final boolean isStrictHeaderNameValidationSet = Boolean.parseBoolean(System.getProperty(STRICT_HEADER_NAME_VALIDATION_RFC_9110));
     

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
@@ -22,14 +22,11 @@ import static org.glassfish.grizzly.http.util.HttpCodecUtils.skipSpaces;
 import static org.glassfish.grizzly.utils.Charsets.ASCII_CHARSET;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import java.util.regex.Pattern;
 import org.glassfish.grizzly.Buffer;
 import org.glassfish.grizzly.Connection;
 import org.glassfish.grizzly.Grizzly;
@@ -120,8 +117,6 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
     private static final boolean isStrictHeaderNameValidationSet = Boolean.parseBoolean(System.getProperty(STRICT_HEADER_NAME_VALIDATION_RFC_9110));
     
     private static final boolean isStrictHeaderValueValidationSet = Boolean.parseBoolean(System.getProperty(STRICT_HEADER_VALUE_VALIDATION_RFC_9110));
-    
-    private static final String REGEX_RFC_9110_INVALID_CHARACTERS = "(\\\\n)|(\\\\0)|(\\\\r)|(\\\\x00)|(\\\\x0A)|(\\\\x0D)";
 
     /**
      * File cache probes
@@ -830,6 +825,20 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
         while (offset < limit) {
             final byte b = input[offset];
             if (b == Constants.CR) {
+                if (isStrictHeaderValueValidationSet) {
+                    if (offset + 1 < limit) {
+                        final byte b2 = input[offset + 1];
+                        if (b2 == Constants.LF) {
+                            // Continue for next parsing without the validation
+                            offset++;
+                            continue;
+                        }
+                    } else {
+                        // not enough data
+                        parsingState.offset = offset - arrayOffs;
+                        return -1;
+                    }
+                }
             } else if (b == Constants.LF) {
                 // Check if it's not multi line header
                 if (offset + 1 < limit) {
@@ -842,10 +851,6 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
                         parsingState.offset = offset + 1 - arrayOffs;
                         finalizeKnownHeaderValues(httpHeader, parsingState, input, arrayOffs + parsingState.start, arrayOffs + parsingState.checkpoint2);
                         parsingState.headerValueStorage.setBytes(input, arrayOffs + parsingState.start, arrayOffs + parsingState.checkpoint2);
-                        if (isStrictHeaderValueValidationSet) {
-                            //make validation with regex mode
-                            validateRFC9110Characters(input, arrayOffs + parsingState.start, arrayOffs + parsingState.checkpoint2);
-                        }
                         return 0;
                     }
                 }
@@ -866,35 +871,15 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
                 }
                 parsingState.checkpoint2 = parsingState.checkpoint;
             }
-            
+
+            if (isStrictHeaderValueValidationSet && !CookieHeaderParser.isText(b)) {
+                throw new IllegalStateException(
+                        "An invalid character 0x" + Integer.toHexString(b) + " was found in the header value");
+            }
             offset++;
         }
         parsingState.offset = offset - arrayOffs;
         return -1;
-    }
-
-    private static void validateRFC9110Characters(final byte[] headerValueContent, int start, int end) {
-        if (headerValueContent != null) {
-            if (isInvalidCharacterAvailable(start, end, headerValueContent)) {
-                throw new IllegalStateException(
-                        "An invalid character NUL, LF or CR found in the header value: " + headerValueContent.toString());
-            }
-        }
-    }
-
-    /**
-     * This method evaluates the String from the bytes that contains Header Value and validates if contains literal value
-     * of \n, \r or \0 , in case any of those characters are available return true
-     * @param start index of the starting point to extract characters from the byte array
-     * @param end index of the end point to extract characters from the byte array
-     * @param bytesFromByteChunk represents the bytes from the request message to be processed
-     * @return Boolean true if any of those characters are available
-     */
-    private static boolean isInvalidCharacterAvailable(int start, int end, byte[] bytesFromByteChunk) {
-        byte[] bytesFromHeaderValue = Arrays.copyOfRange(bytesFromByteChunk, start, end);
-        String uft8String = new String(bytesFromHeaderValue, StandardCharsets.UTF_8);
-        Pattern pattern = Pattern.compile(REGEX_RFC_9110_INVALID_CHARACTERS);
-        return pattern.matcher(uft8String).find();
     }
 
     private static void finalizeKnownHeaderNames(final HttpHeader httpHeader, final HeaderParsingState parsingState, final byte[] input, final int start,
@@ -1095,7 +1080,7 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
                     b -= Constants.LC_OFFSET;
                 }
                 input.put(offset, b);
-            } else if (b == Constants.CR) {
+            } else if (isStrictHeaderNameValidationSet && b == Constants.CR) {
                 parsingState.offset = offset;
                 final int eol = checkEOL(parsingState, input);
                 if (eol == 0) { // EOL
@@ -1107,7 +1092,7 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
                 }
             }
 
-            if (!CookieHeaderParser.isToken(b)) {
+            if (isStrictHeaderNameValidationSet && !CookieHeaderParser.isToken(b)) {
                 throw new IllegalStateException(
                         "An invalid character 0x" + Integer.toHexString(b) + " was found in the header name");
             }
@@ -1129,6 +1114,20 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
         while (offset < limit) {
             final byte b = input.get(offset);
             if (b == Constants.CR) {
+                if (isStrictHeaderValueValidationSet) {
+                    if (offset + 1 < limit) {
+                        final byte b2 = input.get(offset + 1);
+                        if (b2 == Constants.LF) {
+                            // Continue for next parsing without the validation
+                            offset++;
+                            continue;
+                        }
+                    } else {
+                        // not enough data
+                        parsingState.offset = offset;
+                        return -1;
+                    }
+                }
             } else if (b == Constants.LF) {
                 // Check if it's not multi line header
                 if (offset + 1 < limit) {
@@ -1162,6 +1161,10 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
                 parsingState.checkpoint2 = parsingState.checkpoint;
             }
 
+            if (isStrictHeaderValueValidationSet && !CookieHeaderParser.isText(b)) {
+                throw new IllegalStateException(
+                        "An invalid character 0x" + Integer.toHexString(b) + " was found in the header value");
+            }
             offset++;
         }
         parsingState.offset = offset;

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
@@ -22,11 +22,14 @@ import static org.glassfish.grizzly.http.util.HttpCodecUtils.skipSpaces;
 import static org.glassfish.grizzly.utils.Charsets.ASCII_CHARSET;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import java.util.regex.Pattern;
 import org.glassfish.grizzly.Buffer;
 import org.glassfish.grizzly.Connection;
 import org.glassfish.grizzly.Grizzly;
@@ -109,6 +112,16 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
      * @see #setRemoveHandledContentEncodingHeaders
      */
     private boolean removeHandledContentEncodingHeaders = false;
+    
+    private static final String STRICT_HEADER_NAME_VALIDATION_RFC_9110 = "org.glassfish.grizzly.http.STRICT_HEADER_NAME_VALIDATION_RFC_9110";
+    
+    private static final String STRICT_HEADER_VALUE_VALIDATION_RFC_9110 = "org.glassfish.grizzly.http.STRICT_HEADER_VALUE_VALIDATION_RFC_9110";
+    
+    private static final boolean isStrictHeaderNameValidationSet = Boolean.parseBoolean(System.getProperty(STRICT_HEADER_NAME_VALIDATION_RFC_9110));
+    
+    private static final boolean isStrictHeaderValueValidationSet = Boolean.parseBoolean(System.getProperty(STRICT_HEADER_VALUE_VALIDATION_RFC_9110));
+    
+    private static final String REGEX_RFC_9110_INVALID_CHARACTERS = "(\\\\n)|(\\\\0)|(\\\\r)|(\\\\x00)|(\\\\x0A)|(\\\\x0D)";
 
     /**
      * File cache probes
@@ -782,7 +795,7 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
                     b -= Constants.LC_OFFSET;
                 }
                 input[offset] = b;
-            } else if (b == Constants.CR) {
+            } else if (isStrictHeaderNameValidationSet && b == Constants.CR) {
                 parsingState.offset = offset - arrayOffs;
                 final int eol = checkEOL(parsingState, input, end);
                 if (eol == 0) { // EOL
@@ -794,7 +807,7 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
                 }
             }
 
-            if (!CookieHeaderParser.isToken(b)) {
+            if (isStrictHeaderNameValidationSet && !CookieHeaderParser.isToken(b)) {
                 throw new IllegalStateException(
                         "An invalid character 0x" + Integer.toHexString(b) + " was found in the header name");
             }
@@ -829,6 +842,10 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
                         parsingState.offset = offset + 1 - arrayOffs;
                         finalizeKnownHeaderValues(httpHeader, parsingState, input, arrayOffs + parsingState.start, arrayOffs + parsingState.checkpoint2);
                         parsingState.headerValueStorage.setBytes(input, arrayOffs + parsingState.start, arrayOffs + parsingState.checkpoint2);
+                        if (isStrictHeaderValueValidationSet) {
+                            //make validation with regex mode
+                            validateRFC9110Characters(input, arrayOffs + parsingState.start, arrayOffs + parsingState.checkpoint2);
+                        }
                         return 0;
                     }
                 }
@@ -849,11 +866,35 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
                 }
                 parsingState.checkpoint2 = parsingState.checkpoint;
             }
-
+            
             offset++;
         }
         parsingState.offset = offset - arrayOffs;
         return -1;
+    }
+
+    private static void validateRFC9110Characters(final byte[] headerValueContent, int start, int end) {
+        if (headerValueContent != null) {
+            if (isInvalidCharacterAvailable(start, end, headerValueContent)) {
+                throw new IllegalStateException(
+                        "An invalid character NUL, LF or CR found in the header value: " + headerValueContent.toString());
+            }
+        }
+    }
+
+    /**
+     * This method evaluates the String from the bytes that contains Header Value and validates if contains literal value
+     * of \n, \r or \0 , in case any of those characters are available return true
+     * @param start index of the starting point to extract characters from the byte array
+     * @param end index of the end point to extract characters from the byte array
+     * @param bytesFromByteChunk represents the bytes from the request message to be processed
+     * @return Boolean true if any of those characters are available
+     */
+    private static boolean isInvalidCharacterAvailable(int start, int end, byte[] bytesFromByteChunk) {
+        byte[] bytesFromHeaderValue = Arrays.copyOfRange(bytesFromByteChunk, start, end);
+        String uft8String = new String(bytesFromHeaderValue, StandardCharsets.UTF_8);
+        Pattern pattern = Pattern.compile(REGEX_RFC_9110_INVALID_CHARACTERS);
+        return pattern.matcher(uft8String).find();
     }
 
     private static void finalizeKnownHeaderNames(final HttpHeader httpHeader, final HeaderParsingState parsingState, final byte[] input, final int start,

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
@@ -114,9 +114,9 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
     
     public static final String STRICT_HEADER_VALUE_VALIDATION_RFC_9110 = "org.glassfish.grizzly.http.STRICT_HEADER_VALUE_VALIDATION_RFC_9110";
     
-    private static final boolean isStrictHeaderNameValidationSet = Boolean.parseBoolean(System.getProperty(STRICT_HEADER_NAME_VALIDATION_RFC_9110));
+    private static final boolean isStrictHeaderNameValidationSet = Boolean.parseBoolean((System.getProperty(STRICT_HEADER_NAME_VALIDATION_RFC_9110) == null) ? "true" : System.getProperty(STRICT_HEADER_NAME_VALIDATION_RFC_9110));
     
-    private static final boolean isStrictHeaderValueValidationSet = Boolean.parseBoolean(System.getProperty(STRICT_HEADER_VALUE_VALIDATION_RFC_9110));
+    private static final boolean isStrictHeaderValueValidationSet = Boolean.parseBoolean((System.getProperty(STRICT_HEADER_VALUE_VALIDATION_RFC_9110) == null) ? "true": System.getProperty(STRICT_HEADER_VALUE_VALIDATION_RFC_9110));
 
     /**
      * File cache probes

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
@@ -719,8 +719,8 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
                 if (!parseHeaderName(httpHeader, mimeHeaders, parsingState, input, end)) {
                     return false;
                 }
-                
-                if(parsingState.subState == 0 && parsingState.start== -1) {
+
+                if (parsingState.subState == 0 && parsingState.start == -1) {
                     return true;
                 }
 

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
@@ -849,6 +849,11 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
                         parsingState.offset = offset + 2 - arrayOffs;
                         return -2;
                     } else {
+                        final byte b3 = input[offset - 1];
+                        if (!(b3 == Constants.CR) && isStrictHeaderValueValidationSet) {
+                            throw new IllegalStateException(
+                                    "An invalid character 0x" + Integer.toHexString(b) + " was found in the header value");
+                        }
                         parsingState.offset = offset + 1 - arrayOffs;
                         finalizeKnownHeaderValues(httpHeader, parsingState, input, arrayOffs + parsingState.start, arrayOffs + parsingState.checkpoint2);
                         parsingState.headerValueStorage.setBytes(input, arrayOffs + parsingState.start, arrayOffs + parsingState.checkpoint2);
@@ -1139,6 +1144,12 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
                         parsingState.offset = offset + 2;
                         return -2;
                     } else {
+                        final byte b3 = input.get(offset - 1);
+                        if (!(b3 == Constants.CR) && isStrictHeaderValueValidationSet) {
+                            throw new IllegalStateException(
+                                    "An invalid character 0x" + Integer.toHexString(b) + " was found in the header value");
+                        }
+                        
                         parsingState.offset = offset + 1;
                         finalizeKnownHeaderValues(httpHeader, parsingState, input, parsingState.start, parsingState.checkpoint2);
                         parsingState.headerValueStorage.setBuffer(input, parsingState.start, parsingState.checkpoint2);

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
@@ -1010,10 +1010,10 @@ public abstract class HttpCodecFilter extends HttpBaseFilter implements Monitori
                 parsingState.subState++;
             }
             case 1: { // parse header name
-                if(!parseHeaderName(httpHeader, mimeHeaders, parsingState, input)){
+                if (!parseHeaderName(httpHeader, mimeHeaders, parsingState, input)) {
                     return false;
-                } 
-                
+                }
+
                 if (parsingState.subState == 0 && parsingState.start == -1) { // EOL. ignore field-lines
                     return true;
                 }

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/util/CookieHeaderParser.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/util/CookieHeaderParser.java
@@ -248,6 +248,15 @@ public class CookieHeaderParser {
         }
     }
 
+    public static boolean isText(int c) {
+        // Fast for correct values, slower for incorrect ones
+        try {
+            return isText[c];
+        } catch (ArrayIndexOutOfBoundsException ex) {
+            return false;
+        }
+    }
+
 
     /**
      * Custom implementation that skips many of the safety checks in

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/util/CookieHeaderParser.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/util/CookieHeaderParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  * Copyright 2004, 2022 The Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/http/src/test/java/org/glassfish/grizzly/http/ChunkedTransferEncodingTest.java
+++ b/modules/http/src/test/java/org/glassfish/grizzly/http/ChunkedTransferEncodingTest.java
@@ -151,7 +151,7 @@ public class ChunkedTransferEncodingTest {
     }
 
     public ChunkedTransferEncodingTest(String eol, boolean isChunkWhenParsing) {
-        this.eol = eol;
+        this.eol = "\r\n";
         this.isChunkWhenParsing = isChunkWhenParsing;
     }
 

--- a/modules/http/src/test/java/org/glassfish/grizzly/http/HttpRequestParseTest.java
+++ b/modules/http/src/test/java/org/glassfish/grizzly/http/HttpRequestParseTest.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-
+import java.util.HashMap;
 import org.glassfish.grizzly.Buffer;
 import org.glassfish.grizzly.Connection;
 import org.glassfish.grizzly.SocketConnectorHandler;

--- a/modules/http/src/test/java/org/glassfish/grizzly/http/HttpRequestParseTest.java
+++ b/modules/http/src/test/java/org/glassfish/grizzly/http/HttpRequestParseTest.java
@@ -184,9 +184,9 @@ public class HttpRequestParseTest extends TestCase {
     public void testHeadersN() throws Exception {
         Map<String, Pair<String, String>> headers = new HashMap<>();
         headers.put("Host", new Pair<>("localhost", "localhost"));
-        headers.put("Multi-line", new Pair<>("first\r\n          second\n       third", "first second third"));
+        headers.put("Multi-line", new Pair<>("first\r\n          second\r\n       third", "first second third"));
         headers.put("Content-length", new Pair<>("2345", "2345"));
-        doHttpRequestTest("POST", "/index.html", "HTTP/1.1", headers, "\n");
+        doHttpRequestTest("POST", "/index.html", "HTTP/1.1", headers, "\r\n");
     }
 
     public void testCompleteURI() throws Exception {
@@ -194,7 +194,7 @@ public class HttpRequestParseTest extends TestCase {
         headers.put("Host", new Pair<String, String>(null, "localhost:8180"));
         headers.put("Content-length", new Pair<>("2345", "2345"));
         doHttpRequestTest(new Pair<>("POST", "POST"), new Pair<>("http://localhost:8180/index.html", "/index.html"),
-                new Pair<>("HTTP/1.1", "HTTP/1.1"), headers, "\n", false);
+                new Pair<>("HTTP/1.1", "HTTP/1.1"), headers, "\r\n", false);
     }
 
     public void testCompleteEmptyURI() throws Exception {
@@ -202,7 +202,7 @@ public class HttpRequestParseTest extends TestCase {
         headers.put("Host", new Pair<String, String>(null, "localhost:8180"));
         headers.put("Content-length", new Pair<>("2345", "2345"));
         doHttpRequestTest(new Pair<>("POST", "POST"), new Pair<>("http://localhost:8180", "/"),
-                new Pair<>("HTTP/1.1", "HTTP/1.1"), headers, "\n", false);
+                new Pair<>("HTTP/1.1", "HTTP/1.1"), headers, "\r\n", false);
     }
 
     public void testDecoderOK() {
@@ -246,7 +246,7 @@ public class HttpRequestParseTest extends TestCase {
     }
 
     public void testDecoderOverflowHeader2() {
-        doTestDecoder("GET /index.html HTTP/1.0\nHost: localhost\n\n", 42);
+        doTestDecoder("GET /index.html HTTP/1.0\r\nHost: localhost\r\n\r\n", 50);
     }
 
     public void testDecoderOverflowHeader3() {
@@ -263,7 +263,7 @@ public class HttpRequestParseTest extends TestCase {
     }
 
     public void testChunkedTransferEncodingCaseInsensitive() {
-        HttpPacket packet = doTestDecoder("POST /index.html HTTP/1.1\nHost: localhost\nTransfer-Encoding: CHUNked\r\n\r\n0\r\n\r\n", 4096);
+        HttpPacket packet = doTestDecoder("POST /index.html HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: CHUNked\r\n\r\n0\r\n\r\n", 4096);
         assertTrue(packet.getHttpHeader().isChunked());
     }
 

--- a/modules/http/src/test/java/org/glassfish/grizzly/http/HttpResponseParseTest.java
+++ b/modules/http/src/test/java/org/glassfish/grizzly/http/HttpResponseParseTest.java
@@ -84,7 +84,7 @@ public class HttpResponseParseTest extends TestCase {
         headers.put("Header1", new Pair<>("localhost", "localhost"));
         headers.put("Multi-line", new Pair<>("first\n          second\n       third", "first seconds third"));
         headers.put("Content-length", new Pair<>("2345", "2345"));
-        doHttpResponseTest("HTTP/1.0", 200, "DONE", headers, "\n");
+        doHttpResponseTest("HTTP/1.0", 200, "DONE", headers, "\r\n");
     }
 
     public void testDecoder100continueThen200() {

--- a/modules/http/src/test/java/org/glassfish/grizzly/http/HttpSemanticsTest.java
+++ b/modules/http/src/test/java/org/glassfish/grizzly/http/HttpSemanticsTest.java
@@ -677,7 +677,7 @@ public class HttpSemanticsTest extends TestCase {
     public void testExplicitConnectionCloseHeader() throws Throwable {
         final TCPNIOConnection connection = new TCPNIOConnection(TCPNIOTransportBuilder.newInstance().build(), null);
 
-        Buffer requestBuf = Buffers.wrap(connection.getMemoryManager(), "GET /path HTTP/1.1\n" + "Host: localhost:" + PORT + '\n' + '\n');
+        Buffer requestBuf = Buffers.wrap(connection.getMemoryManager(), "GET /path HTTP/1.1\r\n" + "Host: localhost:" + PORT + "\r\n" + "\r\n");
 
         FilterChainContext ctx = FilterChainContext.create(connection);
         ctx.setMessage(requestBuf);

--- a/modules/http2/pom.xml
+++ b/modules/http2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/http2/pom.xml
+++ b/modules/http2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/monitoring/grizzly/pom.xml
+++ b/modules/monitoring/grizzly/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/modules/monitoring/grizzly/pom.xml
+++ b/modules/monitoring/grizzly/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/modules/monitoring/http-server/pom.xml
+++ b/modules/monitoring/http-server/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/modules/monitoring/http-server/pom.xml
+++ b/modules/monitoring/http-server/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/modules/monitoring/http/pom.xml
+++ b/modules/monitoring/http/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/modules/monitoring/http/pom.xml
+++ b/modules/monitoring/http/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/modules/monitoring/pom.xml
+++ b/modules/monitoring/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/monitoring/pom.xml
+++ b/modules/monitoring/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>grizzly-modules</artifactId>

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>grizzly-modules</artifactId>

--- a/modules/portunif/pom.xml
+++ b/modules/portunif/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/portunif/pom.xml
+++ b/modules/portunif/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/websockets/pom.xml
+++ b/modules/websockets/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/websockets/pom.xml
+++ b/modules/websockets/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,12 +24,12 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-bom</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>boms/bom/pom.xml</relativePath>
     </parent>
 
     <artifactId>grizzly-project</artifactId>
-    <version>4.0.0.payara-p1</version> <!-- Version must be repeated so versions-maven-plugin:set works correctly -->
+    <version>4.0.2.payara-p2-SNAPSHOT</version> <!-- Version must be repeated so versions-maven-plugin:set works correctly -->
     <packaging>pom</packaging>
 
     <name>grizzly-project</name>

--- a/pom.xml
+++ b/pom.xml
@@ -24,12 +24,12 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-bom</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>boms/bom/pom.xml</relativePath>
     </parent>
 
     <artifactId>grizzly-project</artifactId>
-    <version>4.0.2.payara-p2-SNAPSHOT</version> <!-- Version must be repeated so versions-maven-plugin:set works correctly -->
+    <version>4.0.0.payara-p2-SNAPSHOT</version> <!-- Version must be repeated so versions-maven-plugin:set works correctly -->
     <packaging>pom</packaging>
 
     <name>grizzly-project</name>

--- a/samples/connection-pool-samples/pom.xml
+++ b/samples/connection-pool-samples/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/samples/connection-pool-samples/pom.xml
+++ b/samples/connection-pool-samples/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/samples/framework-samples/pom.xml
+++ b/samples/framework-samples/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/samples/framework-samples/pom.xml
+++ b/samples/framework-samples/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/samples/http-ajp-samples/pom.xml
+++ b/samples/http-ajp-samples/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/samples/http-ajp-samples/pom.xml
+++ b/samples/http-ajp-samples/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/samples/http-jaxws-samples/pom.xml
+++ b/samples/http-jaxws-samples/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/samples/http-jaxws-samples/pom.xml
+++ b/samples/http-jaxws-samples/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/samples/http-multipart-samples/pom.xml
+++ b/samples/http-multipart-samples/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/samples/http-multipart-samples/pom.xml
+++ b/samples/http-multipart-samples/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/samples/http-samples/pom.xml
+++ b/samples/http-samples/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/samples/http-samples/pom.xml
+++ b/samples/http-samples/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/samples/http-server-samples/pom.xml
+++ b/samples/http-server-samples/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/samples/http-server-samples/pom.xml
+++ b/samples/http-server-samples/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/samples/portunif/pom.xml
+++ b/samples/portunif/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/samples/portunif/pom.xml
+++ b/samples/portunif/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/samples/tls-sni-samples/pom.xml
+++ b/samples/tls-sni-samples/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.2.payara-p2-SNAPSHOT</version>
+        <version>4.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/samples/tls-sni-samples/pom.xml
+++ b/samples/tls-sni-samples/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.glassfish.grizzly</groupId>
         <artifactId>grizzly-project</artifactId>
-        <version>4.0.0.payara-p1</version>
+        <version>4.0.2.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
This is a PR to include new properties on the grizzly implementation to enable Header Name and Header Value validation against invalid characters mentioned on the RFC-9110, here the reference of the reported issue: [Glassfish issue](https://github.com/eclipse-ee4j/glassfish/issues/25128 ) and here the reserved CVE [CVE-2024-45687](https://www.cve.org/CVERecord?id=CVE-2024-45687)

To test this set the dependency version on the payara server: 4.0.2.payara-p2 build and run
deploy the following reproducer: 
[ReproducerJDK11.zip](https://github.com/user-attachments/files/17711134/ReproducerJDK11.zip)

By default grizzly is setting two new properties that enable the validation of the headers by default. You can customize this behavior by seeting the following properties from UI or by cli command o directly on the domain.xml file 

- -Dorg.glassfish.grizzly.http.STRICT_HEADER_NAME_VALIDATION_RFC_9110=true
- -Dorg.glassfish.grizzly.http.STRICT_HEADER_VALUE_VALIDATION_RFC_9110=true

![image](https://github.com/user-attachments/assets/814d709c-2668-4f31-b17c-aae104bdd409)

![image](https://github.com/user-attachments/assets/4ba7231a-2e2a-4ab2-9c60-95ebd4eb1bfc)

`
asadmin create-jvm-options --target=server-config "-Dorg.glassfish.grizzly.http.STRICT_HEADER_NAME_VALIDATION_RFC_9110\=true"
`

`
asadmin create-jvm-options --target=server-config "-Dorg.glassfish.grizzly.http.STRICT_HEADER_VALUE_VALIDATION_RFC_9110\=true"
`

after adding the properties you need to restart the server

by default on the grizzly side those properties are set as true

deploy the reproducer and make curl calls

Header Name Validation tests:

-  curl -i -v -H $'X-MyHeader\n: hello' http://localhost:8080/PayaraServletProject-1.0-SNAPSHOT/PayaraServletProject
- curl -i -v -H $'X-MyHeader\r: hello' http://localhost:8080/PayaraServletProject-1.0-SNAPSHOT/PayaraServletProject

the result of any of those test should be error 400:
![image](https://github.com/user-attachments/assets/40e914e7-ee01-4bff-8cee-20ad936f3217)

this will return status 200  but the header will be discarted because of the \0 character
- curl -i -v -H $'X-MyHeader\0: hello' http://localhost:8080/PayaraServletProject-1.0-SNAPSHOT/PayaraServletProject

![image](https://github.com/user-attachments/assets/cc66442e-8dd7-45ce-9351-0c1ca299ff00)

Header Value Validations tests:
- curl -i -v -H $'X-MyHeader: he\nllo' http://localhost:8080/PayaraServletProject-1.0-SNAPSHOT/PayaraServletProject
![image](https://github.com/user-attachments/assets/6e7ffde3-3336-450f-902a-77141c398df5)
- curl -i -v -H $'X-MyHeader: he\rllo' http://localhost:8080/PayaraServletProject-1.0-SNAPSHOT/PayaraServletProject 
![image](https://github.com/user-attachments/assets/104f6bdc-7db5-433b-b47e-21bf14eaa8e5)
- curl -i -v -H $'X-MyHeader: he\0llo' http://localhost:8080/PayaraServletProject-1.0-SNAPSHOT/PayaraServletProject
![image](https://github.com/user-attachments/assets/b057dcbc-d96f-48a4-933c-3177e4ab3352)


The \0 is immediately not processed from curl because by default we can't consider that character on the request headers and the the \r and \n characters are not permitted alone on the header value content